### PR TITLE
Updated Brand Guidelines from 1.0.0 to 1.1.0

### DIFF
--- a/Presearch - Brand Guidelines - 1.1.0.pdf
+++ b/Presearch - Brand Guidelines - 1.1.0.pdf
@@ -4392,4 +4392,2296 @@ kP4YIP2]qWRSNmu*KJ7n\_,2Cno;F9Q9j(P/*0S1=8^NPE2BPX>MZ&X2`i!aShG>K
 0000878200 00000 n
 0000882509 00000 n
 0000943898 00000 n
-trailer<</Size 96/Root 1 0 R/Info 95 0 R/ID[<15C714B85E4E4D4F8AB0F10B2A2B6432><E1FB8C32E0F2497192105B6578A61FC6>]>>startxref944117%%EOF
+trailer<</Size 96/Root 1 0 R/Info 95 0 R/ID[<15C714B85E4E4D4F8AB0F10B2A2B6432><E1FB8C32E0F2497192105B6578A61FC6>]>>startxref944117%%EOF1 0 obj<</AcroForm 137 0 R/Metadata 2 0 R/OCProperties<</D<</ON[20 0 R]/Order 21 0 R/RBGroups[]>>/OCGs[20 0 R]>>/Pages 3 0 R/Type/Catalog>>endobj2 0 obj<</Length 44981/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 9.1-c001 79.675d0f7, 2023/06/11-19:21:16        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:illustrator="http://ns.adobe.com/illustrator/1.0/"
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Presearch - Brand Guidelines - 1.0.0</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <xmp:MetadataDate>2024-06-26T14:39:05-07:00</xmp:MetadataDate>
+         <xmp:ModifyDate>2024-06-26T14:39:05-07:00</xmp:ModifyDate>
+         <xmp:CreateDate>2019-01-29T13:30:10-05:00</xmp:CreateDate>
+         <xmp:CreatorTool>Adobe Illustrator CC 23.0 (Macintosh)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>20</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAFAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8ADPbXKQpO8TrDJtHKVIVv&#xA;k3Q9M9WE4k1e7wBiavoj/K3/ACk+kf8AMbbf8nVyjW/3E/6kvubtN/ex/rD7305a31leK7WlxFcL&#xA;G5jkaJ1cK605KeJNGFRUZ5g9yxjW7yG31thNDdujKrGSGScIONaUjjotSeu+Z2PKBjra/wCqD9ri&#xA;Thc76e8/cn1mUkuIyHO0fML6rA7kj4ofp65hz5uTHkk9n5kiu/NdxYW8kUtxChjnt1u3PCKOZkMv&#xA;oelQPyqp+LtSuZmTHGGMCRqRHEPT3jvvk48JylMkcuX1d3lXNrzjqtjZXdkl2ZQjBjWKaSI06Goj&#xA;py+k5DT5BGJ7/wCqD9/JlmgZEfrITLSNV0w6Kt/64isQaCe4fiBRvT+J5D3bbc5XKMskqiLJ7h+g&#xA;MwRCO5oebzz87kbUD5dFgDdmcXZhEA9TmKQmq8K8tt9s6X2bPh+Lx+muG72/nOk7a9fBw73xcvgk&#xA;f5dM2mW2vC+jlgdBaiSPlJbyglnI+JRzWv4jMjtzLH93IEEerukOjT2Xjl6xW+3k9L8u63De2t0N&#xA;JUyXlvGrtFcyyMlXJAHqvyanwHOXnKMpeo+nyAH2O9jGUY7DfzP6Uu/Mm5u7ryLqPrLbJDzt1EsE&#xA;7Tjl66V5D0kpQb7V+WZ/YwgNVHhJP1dAP4T/AEi4naRkcEuIAcut9fc898r2ukW3nnRP0XM06mNz&#xA;OrrIrCYQvypzRPhb9n8c6LWzyS0uTxBW+3LlY8zu6fSxgM8OE3+ui9Q0CZjccGtrqJgAA808s6kV&#xA;qa+oaA9Ogzk8+QS5V/pRH7noMMCOf+6JS3T/ADX5t1jzXdaVpl/pCWtq8hlDWt3NMkUciIAxM1uh&#xA;Y/Eu3dgdwpDa5zGSWWt3M2qCzeS2ZeTqRH6gf4AT0YU7eOKsf1PzFpVr5iuo7r10MUgqy3E3CqqC&#xA;KQqQlD3zPjlAxgbX/VH383EOMmd/74/cy68NwNLP1f1/WovH6sITL9oV4/WP3fTrXt75hS5uVHkh&#xA;vLthqdvarNf6lf3klxFGxttRWwWSBiWdlP1GGJC45hG+Jl+Ece7NFKV+dNWtLG6tPX9QlkcqI55Y&#xA;AdwDyEf2qe/TMzTZBEG/9yD97jZ4EkV95H3JF528xLbeS7PU7G7ltY3uUhWX1pIyRwkBDOGDNvH3&#xA;OX6XDDLlIndUTtt1atRkljhced9UD5i84/mBCnLSpIH+r3hiuFEUbsYAe4eSMhtt+IPyyvW6eGMQ&#xA;4b3G7PS5pTMuLoWWXGrzv5Liv9TSSGZ2AmVWe3cESkChQclrxH0Zj6eQjKz91/YW7NEmND76VvKO&#xA;pW18jmBJV4Greq8koPIbcXk3PTpk9RIS5fdX3MMMSOf32wbzSnPzAWs7CID6yfrD2mpW1GkVuMbT&#xA;RyR8kkBrxj7mvdcxXIZ/5V9BfLEIt4oY1SMr6UFyLxQyqBx9cKvIilOmGPMIlyQfl/kXJaC5i4/C&#xA;rTzyzctwekh2P0Zn58glyr/Sgfc4mKBHP7yURL598uxyyRNMS0TtG9ChHJGKsPtdiM17mKll510O&#xA;9u4rW3kLTTNxQVTr/wAFiqQax5j0+z165jlEpeOVS1LmZUFAOkS/B8x0ObGGSPABfT+aPvcOUJcR&#xA;Nf7I/cnmpa1f6TOLm7lsINC9IKJrqf6s/wBYJJp6jkpx4KdqV+7MCQ3coGgo6f560vUbkWun3ul3&#xA;ly26wW+pQyyHtsqKTkaSSHhkfmvzPbaXbWUU7wWUW0JVAvIci1C1PiFT0OelnQ4JZDIi5F4karKI&#xA;iINRRGh+YdZvvMWlRXVy0kbXttyWigGkykdAO+V6nSY4YZmIo8EvuZ4M85ZIgn+Ife99ttI8rXE0&#xA;l1bWVjLMs/OWeOKFmFwh5cmZRX1AWrXrvnAfm8tcPHKqrmeXd7nrvy+O74Y3z5DmuuJofrbRc19X&#xA;r6dRyp4064YRPDfREpC6ck0ZuFt2kdTLGwHExrx3J5A1EldvllE+bbHkwmHytpi6qtzBqt78Mqr6&#xA;vr2zLWObm7s/LmasKHvTbAUhmWrQaYXhS79N2VaR+sQWPbq25y7FAkbBrySAO5au9H03UNDn027H&#xA;p2MnESBCEoqEMN+gFVyePPLDkE48wxniGSBjLkWAfmpdTaDL5Un0p+cloLr6vI/7wtVYhUn9qobO&#xA;g7DgNQMwnylw3/snUdqSOE4zHnHi/Qg/yy1D9Kahr13qgiDTC1EqkBEBQOqih2H2RlnbeAQx44Q3&#xA;A4vPua+y8plKcpeSfefTHp+gRS6deHSBNcxLJe25daIVc7+j8TD5Zr+ycQllIlHj9J2NeXe5naEy&#xA;MYIlw78/7GKeSL651PzPbWWp6sda0+VJjNp7m4kjbhGzqzRTIqMQwFOprm47RxRxYDLHDw5CvV6Q&#xA;dz3xNut0WSU8ojOXHHfbc9O4vQ/K2k6QIbq5bQ4bC6t5ZPq8zWxjf0iKI6vIisCVrUDpnO6vLkBE&#xA;RklOJAv1Xv1HN3OnhA2TARI5emtvkm8E0MpDROsig0JUhhX6MxpRI5t8ZA8kJoctrHr2pWyreG5a&#xA;ru86P6HFHJ/dyFVUk+t9w9sjk0xjjE7FHz3+TKGcSmY0bHlt81ul/WpNdk5LcrHG0jEyt+7I3UUH&#xA;AV67b5jNyhfeXfL13qlzLLGst1I3KVeZJFNq8a7ZkiB4QaaDMXVpnrqxN5flWWOGVCEqlxA93Gfj&#xA;HWCOjP8AR069sx8nMuThNEH9NfagvKvlw6bPJdpDpUNtcRAwx6fprWMwLkO/qSGeXmGbenpqa9ch&#xA;EU2ZcvFt6vib/Qi9cs9IuZ4Vvo4ZJKUiEvGu56LXMnFAkE04mSQB5vMf+cgZrbSPy3tPQjMcK6nC&#xA;qxxAD7UM5Ox998tx5eCV+TCcOONM3/w7c3Wn6nDbTBJ5pnMcjqrgEg02cHxyWqzE8NfzWGnxVfvR&#xA;VroQs/Kyadq1wJKSFpJA3pqKuWULTjT+uYuKJJoORkkAN0XoOl2Vi7G0LFJgDVnLigBpSpPjk8go&#xA;MYG3nHnQ6UNb5TX8Lv8AXCClxZyQsjDlVFdLciQGtPUJO3eprlDa9A8l/V18pW4huPrESo1JRbGz&#xA;XauywskbKB7jDHmg8kZBNDKQ0TrIoNCVIYV+jMqUSObRGQPJL08h6cmpTXourkCYszQrIUWrszNu&#xA;tG3JH3ZiOQmEHljT4J45kluecbBlDXEhFQa7gncYqxjVvJtjqWu3Vw97RpHLPAnEutAB7/qzJGM0&#xA;D0aeMXSZ+ZfLl9r6wWV1DZ3OhikrQyiZLgTKGUMkiOAKcv5a5COWUJXE0VnhjkiBIWEHof5TeVdG&#xA;1SDUrK0VbmA1jdpbmTjvUlRJK6g/RhyanJMVKRI80Q02OJsCik5/5UbwFfR4fs/710+jN/8A66ef&#xA;+xdV/gPl/slbTv8AlS36QtfqPo/XfVj+q8frNfV5DhSu32qZDN/KXAeK+Gjf08urPH+S4hw1xXt9&#xA;T0WL0fj9Lj9o8+NPtd6075zjuVGT6j6x58fV/HLBxVtyYHhtVj9D4eHGv7PjTfx3yBu92QWL9Rp8&#xA;HpUqa049a7/jgS1c/UuS/WOPL9nl/DLIcXRhLh6qkfocG4U4fteH45GV9WQroxvzp/gP/Qf8Uen/&#xA;ALs+o8/V/wAj1OPpf7Hrmx7O/NerwPK+XnXP4uFrfA28X4c/0KHlP/lXNbv/AA76VaJ9b4+t0q3C&#xA;vq+9cs135z0+NfWuX6GGl/Lb+HXnz/SjfNH+Df0Uv6f9P9HeovHl6nHnQ8f7vfpXKdF+Z8T9zfHX&#xA;l+lt1Xg8H7z6Uo8rf8qq/TUP+H/S/SnF/R4evWnE8/t/D9muZet/P+GfGvg/zf0OPpfynGPDri+L&#xA;OG48Ty+zTf5ZpA7QoaL9Hf7q40r+zWlfoyyXH1axw9EVlTY7FUM31D1mrx9X9vxy0cdeTD035q6+&#xA;n6YpTh2r0/HKyyC4Upt07YEqFx9T5p6/Hn+xy6/RlkOKtmEuHqhNS/w99T/3K/VfqfMf72cPT50N&#xA;P734eVK5GV9WQromK8N+FOu9PHIpWXHoen+/p6dd+XSuShd7MZVW6yD6pUelStNqV6YZcXVRXRdP&#xA;9U+H6x6ffj6lPppXIMlRuPE8vs03+WEKUNF+jv8AdXGlf2a0r9GWS4+rWOHoisqbHYqhW/R/rNXj&#xA;6v7fj9OW+uvJh6bRKceA4fZ7ZWWQbwJf/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <xmpMM:InstanceID>uuid:eecbf85a-827e-48e8-b9a3-f30615cbcc19</xmpMM:InstanceID>
+         <xmpMM:DocumentID>xmp.did:190ddeba-a139-4b41-9eb1-38d2c6e9d89e</xmpMM:DocumentID>
+         <xmpMM:OriginalDocumentID>uuid:5D20892493BFDB11914A8590D31508C8</xmpMM:OriginalDocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>uuid:6a4942c9-3310-7041-adb4-7d5533119c30</stRef:instanceID>
+            <stRef:documentID>xmp.did:0f4b7733-6de2-4a28-957b-2e89a11eee94</stRef:documentID>
+            <stRef:originalDocumentID>uuid:5D20892493BFDB11914A8590D31508C8</stRef:originalDocumentID>
+            <stRef:renditionClass>proof:pdf</stRef:renditionClass>
+         </xmpMM:DerivedFrom>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:d00941e1-6ad2-4e14-878c-be0b9de829c7</stEvt:instanceID>
+                  <stEvt:when>2018-11-06T11:14:15-05:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:190ddeba-a139-4b41-9eb1-38d2c6e9d89e</stEvt:instanceID>
+                  <stEvt:when>2019-01-29T13:29:51-05:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <illustrator:StartupProfile>Print</illustrator:StartupProfile>
+         <xmpTPg:HasVisibleOverprint>True</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:HasVisibleTransparency>True</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>841.890000</stDim:w>
+            <stDim:h>595.280000</stDim:h>
+            <stDim:unit>Points</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:Fonts>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>MyriadPro-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Myriad Pro</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 2.106;PS 2.000;hotconv 1.0.70;makeotf.lib2.5.58329</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>MyriadPro-Regular.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Light</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Light</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.5474.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.175.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Medium</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Medium</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.25136.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Semibold</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Semibold</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.173.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Bold</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Bold</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.139.otf</stFnt:fontFileName>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpTPg:Fonts>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Magenta</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+               <rdf:li>Black</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Default Swatch Group</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>White</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>Black</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>35</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>32</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Red</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Yellow</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Green</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>166</xmpG:green>
+                           <xmpG:blue>81</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Cyan</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>174</xmpG:green>
+                           <xmpG:blue>239</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Blue</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>46</xmpG:red>
+                           <xmpG:green>49</xmpG:green>
+                           <xmpG:blue>146</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Magenta</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>236</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>140</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=15 M=100 Y=90 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>190</xmpG:red>
+                           <xmpG:green>30</xmpG:green>
+                           <xmpG:blue>45</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=90 Y=85 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>239</xmpG:red>
+                           <xmpG:green>65</xmpG:green>
+                           <xmpG:blue>54</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=80 Y=95 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>90</xmpG:green>
+                           <xmpG:blue>41</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=50 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>247</xmpG:red>
+                           <xmpG:green>148</xmpG:green>
+                           <xmpG:blue>29</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=35 Y=85 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>251</xmpG:red>
+                           <xmpG:green>176</xmpG:green>
+                           <xmpG:blue>64</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=5 M=0 Y=90 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>249</xmpG:red>
+                           <xmpG:green>237</xmpG:green>
+                           <xmpG:blue>50</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=20 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>215</xmpG:red>
+                           <xmpG:green>223</xmpG:green>
+                           <xmpG:blue>35</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>141</xmpG:red>
+                           <xmpG:green>198</xmpG:green>
+                           <xmpG:blue>63</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>57</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>74</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=10 Y=100 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>148</xmpG:green>
+                           <xmpG:blue>68</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=90 M=30 Y=95 K=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>104</xmpG:green>
+                           <xmpG:blue>56</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=0 Y=75 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>43</xmpG:red>
+                           <xmpG:green>182</xmpG:green>
+                           <xmpG:blue>115</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=80 M=10 Y=45 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>167</xmpG:green>
+                           <xmpG:blue>157</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=70 M=15 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>39</xmpG:red>
+                           <xmpG:green>170</xmpG:green>
+                           <xmpG:blue>225</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=50 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>27</xmpG:red>
+                           <xmpG:green>117</xmpG:green>
+                           <xmpG:blue>188</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=95 Y=5 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>43</xmpG:red>
+                           <xmpG:green>57</xmpG:green>
+                           <xmpG:blue>144</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=100 Y=25 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>38</xmpG:red>
+                           <xmpG:green>34</xmpG:green>
+                           <xmpG:blue>98</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=100 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>102</xmpG:red>
+                           <xmpG:green>45</xmpG:green>
+                           <xmpG:blue>145</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=100 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>146</xmpG:red>
+                           <xmpG:green>39</xmpG:green>
+                           <xmpG:blue>143</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=35 M=100 Y=35 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>158</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>99</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=10 M=100 Y=50 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>218</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>92</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=95 Y=20 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>238</xmpG:red>
+                           <xmpG:green>42</xmpG:green>
+                           <xmpG:blue>123</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=25 M=25 Y=40 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>194</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>155</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=45 Y=50 K=5</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>155</xmpG:red>
+                           <xmpG:green>133</xmpG:green>
+                           <xmpG:blue>121</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=50 Y=60 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>114</xmpG:red>
+                           <xmpG:green>102</xmpG:green>
+                           <xmpG:blue>88</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=55 M=60 Y=65 K=40</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>89</xmpG:red>
+                           <xmpG:green>74</xmpG:green>
+                           <xmpG:blue>66</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=25 M=40 Y=65 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>196</xmpG:red>
+                           <xmpG:green>154</xmpG:green>
+                           <xmpG:blue>108</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=30 M=50 Y=75 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>169</xmpG:red>
+                           <xmpG:green>124</xmpG:green>
+                           <xmpG:blue>80</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=35 M=60 Y=80 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>139</xmpG:red>
+                           <xmpG:green>94</xmpG:green>
+                           <xmpG:blue>60</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=65 Y=90 K=35</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>117</xmpG:red>
+                           <xmpG:green>76</xmpG:green>
+                           <xmpG:blue>41</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=70 Y=100 K=50</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>96</xmpG:red>
+                           <xmpG:green>57</xmpG:green>
+                           <xmpG:blue>19</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=70 Y=80 K=70</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>60</xmpG:red>
+                           <xmpG:green>36</xmpG:green>
+                           <xmpG:blue>21</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>2d8eff</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>45</xmpG:red>
+                           <xmpG:green>142</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=14 G=50 B=79</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>14</xmpG:red>
+                           <xmpG:green>50</xmpG:green>
+                           <xmpG:blue>79</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=243 G=248 B=255</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>243</xmpG:red>
+                           <xmpG:green>248</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=73 G=73 B=73</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>73</xmpG:red>
+                           <xmpG:green>73</xmpG:green>
+                           <xmpG:blue>73</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=250 G=251 B=252</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>250</xmpG:red>
+                           <xmpG:green>251</xmpG:green>
+                           <xmpG:blue>252</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=217 G=234 B=242</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>217</xmpG:red>
+                           <xmpG:green>234</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Grays</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=100</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>35</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>32</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=90</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>65</xmpG:red>
+                           <xmpG:green>64</xmpG:green>
+                           <xmpG:blue>66</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=80</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>88</xmpG:red>
+                           <xmpG:green>89</xmpG:green>
+                           <xmpG:blue>91</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=70</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>109</xmpG:red>
+                           <xmpG:green>110</xmpG:green>
+                           <xmpG:blue>113</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=60</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>128</xmpG:red>
+                           <xmpG:green>130</xmpG:green>
+                           <xmpG:blue>133</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=50</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>147</xmpG:red>
+                           <xmpG:green>149</xmpG:green>
+                           <xmpG:blue>152</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=40</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>167</xmpG:red>
+                           <xmpG:green>169</xmpG:green>
+                           <xmpG:blue>172</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>188</xmpG:red>
+                           <xmpG:green>190</xmpG:green>
+                           <xmpG:blue>192</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=20</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>209</xmpG:red>
+                           <xmpG:green>211</xmpG:green>
+                           <xmpG:blue>212</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>230</xmpG:red>
+                           <xmpG:green>231</xmpG:green>
+                           <xmpG:blue>232</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=5</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Brights</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=100 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=75 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>242</xmpG:red>
+                           <xmpG:green>101</xmpG:green>
+                           <xmpG:blue>34</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=10 Y=95 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>222</xmpG:green>
+                           <xmpG:blue>23</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=10 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>161</xmpG:green>
+                           <xmpG:blue>75</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=90 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>33</xmpG:red>
+                           <xmpG:green>64</xmpG:green>
+                           <xmpG:blue>154</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=60 M=90 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>127</xmpG:red>
+                           <xmpG:green>63</xmpG:green>
+                           <xmpG:blue>152</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+         <pdf:Producer>Adobe PDF library 15.00</pdf:Producer>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+endstreamendobj5 0 obj<</ArtBox[9.0 9.0 850.355 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 253 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 24 0 R/LastModified(D:20240626143905-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 133 0 R/C0_1 136 0 R/T1_0 115 0 R/T1_1 119 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 27 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj6 0 obj<</ArtBox[9.0 9.0 797.17 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 238 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 29 0 R/LastModified(D:20240626143833-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 131 0 R/C0_1 132 0 R/T1_0 116 0 R/T1_1 115 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 30 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj7 0 obj<</ArtBox[9.0 9.0 771.016 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 230 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 32 0 R/LastModified(D:20240626143516-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 26 0 R>>/Font<</C0_0 107 0 R/T1_0 16 0 R/T1_1 14 0 R/T1_2 17 0 R/T1_3 18 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 20 0 R>>>>/Thumb 33 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj8 0 obj<</ArtBox[9.0 9.0 850.585 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 222 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 35 0 R/LastModified(D:20240626143831-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 130 0 R/T1_0 116 0 R/T1_1 115 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 36 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj9 0 obj<</ArtBox[9.0 9.0 850.89 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 214 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 38 0 R/LastModified(D:20240626143656-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 212 0 R>>/Font<</C0_0 111 0 R/T1_0 109 0 R/T1_1 108 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 196 0 R>>>>/Thumb 39 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj10 0 obj<</ArtBox[9.0 9.0 781.685 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 195 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 41 0 R/LastModified(D:20240626143830-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 212 0 R/GS1 213 0 R>>/Font<</C0_0 114 0 R/T1_0 108 0 R/T1_1 109 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 196 0 R>>>>/Thumb 43 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj11 0 obj<</ArtBox[9.0 9.0 729.529 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 187 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 45 0 R/LastModified(D:20240626143744-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 121 0 R/T1_0 115 0 R/T1_1 116 0 R/T1_2 117 0 R/T1_3 118 0 R/T1_4 119 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 46 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj12 0 obj<</ArtBox[9.0 9.0 776.083 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 175 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 48 0 R/LastModified(D:20240626143829-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 124 0 R/T1_0 116 0 R/T1_1 115 0 R/T1_2 119 0 R/T1_3 118 0 R/T1_4 117 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 49 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj13 0 obj<</ArtBox[9.0 9.0 662.029 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 158 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 51 0 R/LastModified(D:20240626143829-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R/GS1 174 0 R>>/Font<</C0_0 126 0 R/T1_0 115 0 R/T1_1 116 0 R/T1_2 118 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>/XObject<</Fm0 159 0 R/Fm1 160 0 R/Fm2 161 0 R>>>>/Thumb 56 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj22 0 obj<</ArtBox[9.0 9.0 784.359 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 138 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 58 0 R/LastModified(D:20240626143826-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 129 0 R/T1_0 116 0 R/T1_1 115 0 R/T1_2 127 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 59 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj95 0 obj<</CreationDate(D:20190129133010-05'00')/Creator(Adobe Illustrator CC 23.0 \(Macintosh\))/ModDate(D:20240626143905-07'00')/Producer(Adobe PDF library 15.00)/Title(Presearch - Brand Guidelines - 1.0.0)>>endobj107 0 obj<</BaseFont/TLURPM+ProximaNova-Bold/DescendantFonts 231 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 232 0 R/Type/Font>>endobj108 0 obj<</BaseFont/FCPYER+ProximaNova-Semibold/Encoding 202 0 R/FirstChar 31/FontDescriptor 203 0 R/LastChar 122/Subtype/Type1/Type/Font/Widths[549 257 0 0 0 0 0 0 0 0 0 0 0 0 0 245 0 616 380 595 574 580 600 601 532 595 601 0 0 0 0 0 0 0 673 648 682 710 577 562 717 723 259 481 621 517 835 720 765 608 765 628 594 577 719 673 903 661 637 589 0 0 0 0 0 0 536 581 497 581 557 308 580 568 241 241 526 241 833 567 573 580 580 347 472 319 567 503 754 496 503 476]>>endobj109 0 obj<</BaseFont/FCPYER+ProximaNova-Regular/Encoding 199 0 R/FirstChar 31/FontDescriptor 200 0 R/LastChar 150/Subtype/Type1/Type/Font/Widths[508 258 0 0 590 0 731 641 0 248 248 0 0 230 300 230 296 612 339 588 557 558 590 591 515 581 591 230 0 0 499 0 0 783 658 629 676 700 569 550 713 712 239 475 601 510 809 708 765 587 765 608 586 570 700 658 883 652 626 585 0 0 0 0 0 0 527 575 495 575 563 283 574 552 225 225 514 225 808 551 572 574 574 330 465 294 551 490 734 486 490 472 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 230 390 390 0 593]>>endobj111 0 obj<</BaseFont/TIOCWC+ProximaNova-Bold/DescendantFonts 215 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 216 0 R/Type/Font>>endobj114 0 obj<</BaseFont/VSSPHH+ProximaNova-Bold/DescendantFonts 205 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 206 0 R/Type/Font>>endobj115 0 obj<</BaseFont/FCPYER+ProximaNova-Semibold/Encoding 144 0 R/FirstChar 31/FontDescriptor 145 0 R/LastChar 122/Subtype/Type1/Type/Font/Widths[549 257 0 0 0 0 0 0 0 0 0 0 0 0 0 245 0 616 380 595 574 580 600 601 532 595 601 0 0 0 0 0 0 0 673 648 682 710 577 562 717 723 259 481 621 517 835 720 765 608 765 628 594 577 719 673 903 661 637 589 0 0 0 0 0 0 536 581 497 581 557 308 580 568 241 241 526 241 833 567 573 580 580 347 472 319 567 503 754 496 503 476]>>endobj116 0 obj<</BaseFont/FCPYER+ProximaNova-Regular/Encoding 147 0 R/FirstChar 31/FontDescriptor 148 0 R/LastChar 150/Subtype/Type1/Type/Font/Widths[508 258 0 0 590 0 731 641 0 248 248 0 0 230 300 230 296 612 339 588 557 558 590 591 515 581 591 230 0 0 499 0 0 783 658 629 676 700 569 550 713 712 239 475 601 510 809 708 765 587 765 608 586 570 700 658 883 652 626 585 0 0 0 0 0 0 527 575 495 575 563 283 574 552 225 225 514 225 808 551 572 574 574 330 465 294 551 490 734 486 490 472 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 230 390 390 0 593]>>endobj117 0 obj<</BaseFont/FCPYER+ProximaNova-Light/Encoding/WinAnsiEncoding/FirstChar 32/FontDescriptor 176 0 R/LastChar 122/Subtype/Type1/Type/Font/Widths[259 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 608 308 582 544 541 582 584 502 571 584 0 0 0 0 0 0 0 647 614 672 692 564 542 711 703 223 470 586 504 790 699 764 571 764 594 581 564 686 647 867 645 618 581 0 0 0 0 0 0 521 571 494 571 567 265 570 540 214 214 505 214 789 540 571 570 570 317 459 275 540 481 719 479 481 469]>>endobj118 0 obj<</BaseFont/FCPYER+ProximaNova-Medium/Encoding/WinAnsiEncoding/FirstChar 32/FontDescriptor 165 0 R/LastChar 122/Subtype/Type1/Type/Font/Widths[258 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 614 359 591 565 569 595 596 523 588 596 0 0 0 0 0 0 0 666 638 679 705 573 556 715 717 249 478 611 513 822 714 765 597 765 618 590 573 710 666 893 656 632 587 0 0 0 0 0 0 532 578 496 578 560 296 577 560 233 233 520 233 820 559 572 577 577 338 468 306 559 497 744 491 497 474]>>endobj119 0 obj<</BaseFont/FCPYER+ProximaNova-Bold/Encoding/WinAnsiEncoding/FirstChar 32/FontDescriptor 178 0 R/LastChar 122/Subtype/Type1/Type/Font/Widths[256 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 620 411 600 587 597 608 608 545 606 608 0 0 0 0 0 0 0 684 663 687 718 583 571 720 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 0 0 0 0 0 0 543 586 499 586 553 327 585 580 253 253 535 253 852 579 574 585 585 360 477 338 579 513 769 504 513 479]>>endobj121 0 obj<</BaseFont/NBCTRX+ProximaNova-Bold/DescendantFonts 188 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 189 0 R/Type/Font>>endobj124 0 obj<</BaseFont/BPSDMV+ProximaNova-Bold/DescendantFonts 180 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 181 0 R/Type/Font>>endobj126 0 obj<</BaseFont/NPXXFS+ProximaNova-Bold/DescendantFonts 167 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 168 0 R/Type/Font>>endobj127 0 obj<</BaseFont/FCPYER+MyriadPro-Regular/Encoding/WinAnsiEncoding/FirstChar 35/FontDescriptor 142 0 R/LastChar 70/Subtype/Type1/Type/Font/Widths[497 0 0 0 0 0 0 0 0 0 0 0 0 513 513 513 513 513 513 513 513 513 513 0 0 0 0 0 0 0 612 542 580 666 492 487]>>endobj129 0 obj<</BaseFont/IGANUC+ProximaNova-Bold/DescendantFonts 150 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 151 0 R/Type/Font>>endobj130 0 obj<</BaseFont/CRRRRP+ProximaNova-Bold/DescendantFonts 223 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 224 0 R/Type/Font>>endobj131 0 obj<</BaseFont/JPZWYG+ProximaNova-Bold/DescendantFonts 246 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 247 0 R/Type/Font>>endobj132 0 obj<</BaseFont/BZVOLB+ProximaNova-Regular/DescendantFonts 239 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 240 0 R/Type/Font>>endobj133 0 obj<</BaseFont/PVNYVU+ProximaNova-Bold/DescendantFonts 261 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 262 0 R/Type/Font>>endobj136 0 obj<</BaseFont/KGZFVT+ProximaNova-Bold/DescendantFonts 254 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 255 0 R/Type/Font>>endobj137 0 obj<</DA(/Helv 0 Tf 0 g )/DR<</Encoding<</PDFDocEncoding 270 0 R>>/Font<</Helv 268 0 R/ZaDb 269 0 R>>>>/Fields[]>>endobj138 0 obj<</Filter/FlateDecode/Length 5242>>stream
+H‰lWK®¹Ü×)ê]â'ùÛZ¼2Ã aÏ,ZÌøþ€#2’Õ-i @¯²š•d~"2øå_Ï/ÿšÎ¿üõëy¤kåyâÿVÏ|þñËñåoÿJç/ÿ;Ê´s2ÚÙV»Ê<ÿøÏñßã÷#=WÚ³­kbI˜øùßçop˜G‡ÃÖ†þ~ä3á_>{º¬–r¶V¯š­œÏoùv”«c»t¾Žz¥QÎGºR]g½¬¸‘—Áè­Ñ°>Î'.ü…9Æ<íÊ=Ÿ|Ñ}™X&×zÆWõjî¾Ã/Œ™³{4.´+M.ÌÏeŒ³\s?>qàx|¿ÒXWZ!èY/lšÌ¶i×ªð0¯•Ìk0ŒyµÜá®ã$•f.ãèc\aD†£vœë&BË´
+ÎkL8lWÃ;ì¡cxëªL ‚BmV¦bÁïmd_æF¾Šñ—ª¤Wÿ&Á+Ò\¦ï;,KÛrq¾òƒ3bWÔožÇ@ÕrVq„gÏ“±v_j–aà3Ãg\ÈÃÙ5ÝÏ¦ççñ`§Í0_Û|düµŠéãùW´ã??Úk4vQ>[EŽ‘ð»»%_©©¿¥ ¾xäÃÊÎZn+ãØ{Ûñçõ~QUL¹)ˆŠ)•Yl=½¼/=,¹ŽïÃÏç!Sÿ¿ÂÒÁä!ù?«#ÆvúóÐô…$‚_ïp=ˆßgu7ùG™ð÷ÑóþZØ¶³Žm"}mGah›ç!3ŽñÚ&Z6ŸòQÐà@¸<…ÁókÿxÁãê|ñâŽÏ=ýíÓëÝÆd(ò ‘ŸrY²Ø'j7D^¯ûÙÌ{úƒoH)i‘¥¦s ˜¯Ìº&`Fo~^Ò#	 ¾6¶9³âh@sõÀœª@2æùãŸ*4W ÓÆÞ Nûša¢½¹2Ld›£¡NÂ@,a“áìRÙ'œ—½ÈŸÌ&öògÄ„sýhƒ‰Zboq=Ðó“MTÙ„»%§©4ÜJÝ‰ifåH`WëÎ›Á*•Ä‘xäqWu²ftHš>„‘+Û{fÏ ¨@þþt“ÒædØ$uf9,w7Ûô­Ã¡â†­þÞ8ÕØ`¾¢jØ ,}µa/Œ©F²¹ò´ŸL:ìoSG€A‡
+PXýžœ2IÉ›±]Õ@âŸÍhƒ.
+Û·²ÏÏ¼«¼e<öad8(:'§{¥£Ì¦&Ë“ÝSYJt\aN`IZïþÆYÍAR`7ÖÝsíZÆfOEõË}^ÚÚ¼Se¨m9Å|]ÙQaü­'¶zÊùm”>µ°[#lWÙÍ;Ïä,²ç¶iW6Òpj¹ˆÐ°ûe¨(™QP|4¢äCKxAÂ iÀÈxùze¹æ®|ð)ËòÁb³Å‘ _GÆéí^~ºS ê¶r*6v%'™ gý«¨<æƒ’fTFž»Ý1ëY*¾UåÔ‚'l¹‘•™+G"ã%÷ŒËšzwUááµ¹‚*Œ#8	FÞlå6Š&_(Ó‰_±òi9ÕJÐ·ÃÜ6>Å8ARhM§ãa™ì;á“»½”¨vçºT= Ë¼‰ËjAÕ^î‘œ‰l8ßfA§¨w”a5Õ¤Šå§	¾e£ì!xMÍQE~.¶TÛM…÷'£4FGâ´&ê ¤Úy[A,:ÏYn2dé]ª¤è ÷ ñá«Îgêµµï#ŠÈ°ŒøýÙ\¶fÀÍÞ6l¼_ðl„¿«[±la}Vº-ÆCò-V^»®ÁáèÙ]½ Ÿs+¸~—ËÅ˜êþ-òÚ.¯göÇœªCÐ³HxRóx:}ÃÍh®ž‚ÍÇš{JnZ^X«™;ìË;¡‘T‰bŸýÏ{@ÝR°7Ð^jß«‡©îKÃTA·¼£ï˜3ê¹´ÈªótS‹æîXšXKí¶üºúÃ~¶¡yZæ-ÃâÏ^prVÙ6½¼Nqdt¯Iø˜¾%LdØ=ÓÙÝýŒ¼ÉøH#qJnEF¦ÒVz™Õe:ncØŸ¤n(fMó»Ä&ÑrÕÝÎ'ì½i<æðKªójˆeð ÉÃMy©MJ¶æ_C¢ÝÀýæ˜ªJŽIu)ŒlQRÛ%Öô\—‡jÿàƒ@ÁÍbòÍ%Áè‘qÒ½½»”¸še‹	òeÛÌw“'Sí+e:»h…Am¸:½*ª…6WiÍÛ	zfIÚR·Xêa0ý›tjŠ²šÑ6Ý·0I+ÔH²0‰4&šÃYâˆ¤ªâ±²œG74 Õ§³bBçÊðsÏÄûîTžÕ¥@Ýs’³/M˜R)VŽk#ï mP6=BPµ‹/Ã{¾ççŠQ£4*Å’	ìxJ9ÚÏµ–{Uö[œ,’¼BÃ‰„å™
+SÝ¹+¸ P~ÌÉº L¬çºa[ÕÙ<ï!@q5ˆ;Á¤B¤æê‘Pa˜Ä‹·‰0LÚãÎA©_)‰ñ¸ 2}½A0õD_R¿S‡ÚÉW†íœ ï÷Í¥Öº£—|à<dÏH@äµg&,kEÙˆûPšM“¾JLŽHODËyZãÑs\qÇÙ Ö˜˜[ä=Tƒ7wÓM}9ÖŠ‰£«`3‘µXüxL](÷-ª‰T/$51é1æÂô¬µ|‡óMc˜cÌµÓ}³Y}GÂ¸lƒÞ(ž‰ÏÔÆÛðÁª!ÿ<B	é»×6÷U/èPæjòÕwÿi.Nd8Äu™¡hù ï¢ë`ÉgÜjnÚöPÕŽ;×@ñ:H<¦uD«n»o=l¢tkªÝR1Ñdy=]ÒÄ¯(koÂž×ÞïÚSœ¸ŠÔ€CÈDÂ>s$¬=ž¸ý|Ü^M2cèŠ£úl–—ÉÑ\é.
+:83Ï„w7`e†2×W·~ê~)³kn.z{ßò}âî%v˜n–d¤€Ô\;³Bst2àÒ=…éØN­?ß’M¿è*)Á°0t”Xr^®›)u$¡@'fcrÂH’¾u N4kÈ¼Í7Ô­Ÿ…ZH®(LºÐ1CD´ Žš""€dù/hnÝºp” I^áà¿jÌ®£Õ#\=Ègú°ñ	"S]Hw…×N{WÏÅ/²œa€Æ^w·´|.w.ÚÙñÑÞ­·¥ËM_B‚šîjºø)œaEÞ’,`DzZÍA1ÓM™e÷7˜$/q q›¨ÍÅ:ýq/øÍvzñ€ù§úÚèó¥Ðâ¼ßD"¨z9Õ\{~èº'®uè\Ò‚ºÏ¨M4ô• )pJû~OVp/OãØ¢`ž¨x‚ìƒ'W[ÀOîª'zÕz8T—lòÇà,û¸¨òˆ((ujÈáy˜Ûßà³9t»’ºçôrIÀc¬³àÛd2‚{çóM…×Q	åw¸&N56¼Ç˜dVH¯ *ÿ=U~ºõæ!üÓ~ø¼Þ¸­ƒoŽmÜ¯pø”ï7 ‰˜}ëƒŠ±¾‡„Âb(Ù™¼}fšoÒõ›x£¨AýÜ$¹µÕŽð›È`}]ÅËŒË«¤cÈt¸p¦×6dàAN$)‡þòÄçWŸAÀ^æ¸›¡¶2œÚÀö}V´ƒˆ{'!µéFñ}Å}©¾×!]öØMøêËµ·qã
+Ãßõ+,
+ˆ…­Ìç,ÙNÑbm ¶(’"ÐZÚµÅÚJr’Ÿß÷Ì™!‡òeÉM¿t¶4ô<snïs"	qSáÆšºÙ¸É%3èð(ZÄ	Â!›¸Qn€ÒŠfƒÉœväª(Š¼¶ª8Ë8Û¦/()ÇŒ–Ä3qaÕ–“nÉS%¢âa¤Íµ“ù’ß’&B8ŸûWe‡2.­œ*);£Ü´x)ÑŠ|Èë]±VqHÈëÜ¹ÒZÄé¥©áPšCe´o+dLªnñyfqm•u:!hìC	ë@²zÈ$5·Bçög[Ç´ä¸á§B²érÈÄ–KFÃXmÞul9Ë~RYH²¼Åtãõ.¯¹4w“ÅRç?¦òr*K2RÓ'¨ƒ6„ÉåÞÖ¾>Œ<’ibÁÆÆ¯,O1æ9<¤ñôÁ²Âû ieKl–—<¡Æ}ô-áÓR4Oa  AÂ§¾Å¼Ã‹(éÎÚ´Üåå%òC6ªsÖÓsÑ_ÆË˜Äz„‘Ýt’P4O2,ƒ<€¤Šµ(Õ
+‹•NJŠ=žßÄÓñp.òÑc-âm¢Êc]åïÙÑ¼âÛxwœù²ô>tGFwîGe žÔ€ÄQìÃFlðý±!öø¶~ÏilŠí£Ð›àZá¢ñH™ÛMqÁé„¶ª}în[tót-!Im7JO/´¹>öL0Ï"Û*Úç—ö…ýŠ'ª€
+æüO‹È1¡MV"¨Xõ¼äyQ$f~8w,Úiƒòx£Ü¥a”*0*tÕ¼HQê·P”BQÙÔ®ÛnþS^–ÍüÅ^†ôr!ÛnNf‡@šù<¤Qê¥žÈ-7¾Ô<Kø’¡ƒ/iÃ})‹Aò|›á‹Š=Ó=¯¤/ªÓ‚¾hÌéè‹®À/í
+þÒ¦ã¯8ctüEçlù‹Îßñ“YË_NülÁ_^—üeSð—QJþ²®0-Jsº$0­
+£BËçÈŽÀH—s² 0
+ ³¡°Äˆ€…À4³S`Á fu`ä`|w`V Æ[ £Þ”L5]ò—³-y–¦Ä_|’–¿¬)øËÉ‚¿X•Zþ
+ºà/í: #+øKó8ÙñWÈôÒ.Hvz¥ÌÂñ×É|I‰èxDg¨'_-Äèy¢Z~˜ ¥ºƒ!¹uÕr=ùƒ ‹B'ð£°žcí±hR	ë[¬±´¸îdÚ‹OgyD6ÍÅ§ ë\þªP-¯é-úŠ®äþkà$j ÚîÃ’Ÿh½ÞbE¹×¡îÜ“½ñÍšß?-Ýs³œ|µÜ?ÞÝÿíÓËÍ¯§›õöT½}Ç~QQ¾»ßä›¥$ßk`i|êœï7!PnÆ7N—÷›êÝasÜ¬w÷ÕÝ~·<TŸV»Íé´Áòá²Nž:ñwÓãöx:VûÕþaS½_ñë°zX§[kVM/ª÷»ÇMíªé¬ªÿµüódù{Üú÷è8]¶ûÇcµ^~¬‘§ÓÍ¡¢ûwÛ÷'|?Þ¯Ö›c{×”þvÚ>ð;O÷éÉÐ»ÕCõ~S‘´÷ñ¸YW¿lO÷Û‡j½ý¸=­vñÙŸx@…Çn?>/ÚíŸûŸ·kÜrþØí±zØŸªÝæxl7Ÿîñ.e~—ÍØÿ¼9¬v»ôÔYtÓ“E$‡A‰|p®"î
+‹ÂðÝTÎj'ª©«lÂ»[§‡èBJ’>áW¢LñÉOÅGcÐœHˆAÕRpçt&~ ÙWdEŒ¨âˆþiS£—Mýºz£®ýÍím±o¿™]}?Õæ¢vè²ÕôBó}ÝíY¼ýç_h“¨A[ øŽ,€@§o"ÝDþ^n%z”¯¼	3ê¦iyØLþQ=ÐI#ý“ÈàPø“êÆD4Ñ2pO÷N4SMÍÎÐ­¸O¿[ç«T›Z¤#Ùm †½?}£¼»½15WÚûqn³4Û5¯×3DRKÔ²äM6„0Ü|àgê·=?5x¬ ±.M±/˜pžƒ#¡1œ‘o”vrQCö§‹1±‹ùÙxŸÈ¶´	>oÀ{ƒl‚*ÀWc ÿÁv¼µÍ\wÚ'qŸ!Ì}c¢a¡²nÑÒ­É¡Å#li‹"ºtiˆltDË^Q@I5NpÄ†¹hš†ð@	õî9óçL³„ÜçQ_\„O¶äZ]éÅK\ôFBJ3”´qš(H/z™ªH*0¼ak§ó©ë”¦ ÿ<°d )ÖÁlm9g‘;nxIÇ§ Ôó”\á@v`CŽHü7¢ŸòDÓP?±=? 7w‡ù¡!fG­G@f7Ì	#Ê%ÄÙ4D{‚¬¾ý×LõK51Dy@ü3;cð+†°ÒU·ñßp•	ÑIñÙÙ¨áòTZƒ¶ë!E}MÒ*„QRÐ?mkÑpM"Cäo–¤&bŠE"öì!Hd‡BÌK=š¾1öJ±C#ka‡?‹Ð";%º'BF»¨1 u®n,Lé8?sæ™Ï)Ñ«‰ŒªT°°/M7W·ÍWù(MAöí!L9súÂtmnü3x†ôö,ƒ‹’f”}QZˆëë1VØ(J$m¥#$Iþ¡¯IWók9Æ	Ê¹³ô¡Gm0øõõ(Ø…eHlÁ®9ËÚÏÂó?²¯^ÎçlÐ³3N9Ë¢… ºxqƒ{×ýÙ%IÝùì’Ç’óIäÙÙåâ|w&Àl&ÆÌ/íÁ_1Kã”±³¸ó+UìÙ)ÆJ4u.J­6Í—*cOû&g»´ðˆÅkiö4ºÁ´Æ“­'Neô4ÿ´–×¯Î€ž€uô¹üB»‡@¡û§é•Žqž^®¹¨üi(u\3*ÃøcÆ‘éVQ]*”œ«–×}+RˆÓ‰I"îHÆHÑK[Ñ¾+¯ÇY–v“ƒ$;è2ÌŒ£ùîM.ZÖN›nj-`â©ZìwûÇÃ±½3¹–o¼T .œåÜ¹I°ž©]òðÙKÂ*ã§wÌÊ{þwEìg·HñáŠ8ÒôˆcÈíyl‡È^Çßž+‡Í£‚‘UŽC½¨'¡®Î s[SçÌo_:­AÂøŠ’¿:d`Ðsž7x–
+ç 3 ´õKµÝæjŠŸÜSÎt'/žU¦¨2)!•‘øQ¯§¥|©üÅÿQåËœ¯î~¬áèéÇÃþñaÝ«|äÉÍÛE5ù¯  ºGø
+endstreamendobj139 0 obj<</Intent 140 0 R/Name(Layer 1)/Type/OCG/Usage 141 0 R>>endobj140 0 obj[/View/Design]endobj141 0 obj<</CreatorInfo<</Creator(Adobe Illustrator 23.0)/Subtype/Artwork>>>>endobj142 0 obj<</Ascent 952/CapHeight 674/CharSet(/numbersign/zero/one/two/three/four/five/six/seven/eight/nine/A/B/C/D/E/F)/Descent -250/Flags 32/FontBBox[-157 -250 1126 952]/FontFamily(Myriad Pro)/FontFile3 143 0 R/FontName/FCPYER+MyriadPro-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 88/Type/FontDescriptor/XHeight 484>>endobj143 0 obj<</Filter/FlateDecode/Length 1709/Subtype/Type1C>>stream
+H‰|T{PTçßËrïb¥kd½÷š½· Nl©<D%¥ky©‹[žWve¯òÝÔÔÆ(¯eIKÉF(… ˆ8<L†g”§°JÀÀ…ª3qF“sñ#Mïnÿé_oæÌï÷ïü¾s¾sîÅŽÃ¶U$ÈÿúÈ«R+té»k’3ST:›“æ(Œssä¶9“h2½yó&
+‡¡M0¹¹c›w8`ØÜJhú9>6Yk`öúzÚ¬ŸÝú{2¾>>>vëÇ¼«N?¥a”ôMªž	OKJ×K×©µónJ
+c—Ð3:^£Ë²mþ7#†Õ3Ö ÕèïLfùxFÍt*µ&U¥;Ë¤Û<ÿCOÿŸ«6áµ˜˜4ÖÆ”~SÏ¨ÒÔÞ¼Jºý–¤ôÌ4ƒŽÕè½¼+ÿpáœ†	`ÔšÓ&p6o¸ãþéG‚Ÿ0w,uxËu˜wø·0Gø½cˆc'.Äð\ü³ÝEÝÜ‹nŒ·Û»…EŽ\þšb=Ÿ $ÑA(Åa•@ê%ÁFÖÿ,Z'Þ·c8ˆxNp=¤!ÿª:â‡`Ç(³±V.X
+(%ÿ;ðWÄy´G4*%ë ž§(&løÙÐoˆJþˆu(¨%®à}JÜÃŽ£íØSñ­=ÜG±`çLpÍØ­%¨\BùÚ.¹íFÎ(Fg‹¿EABÁöC$ 1z›¾ö{ÒÚîŽüPÐI÷=ûãžÃ÷ÿk–Wgq£EÙ.óDÒ
+9®OÖd!„d¹úkà_áÅ„¸ÈÂ™-pKBî¤«}Q,ê¹‡ÃÛà¶øœ¥«Šçˆ	‰L×¼/«?‚×6v5Q/šŽ†Ó…»BüQò=æ#çLÁ_Æ@=å‹ËáVÉjG3™Õ4b°Pà3o}eÞ_A‹$/¿ih—ÎEÏ -òpŽ•ÕDâUõÝ5=Ô|ó‰¸ƒAg"éÄð.B²údAíc¤cŒÚP„SG£k+t¶b@>	ÓO°òe`¹í® ·NúpïxŠPçú^<ú\„X($‹E°2*+ê«no5l!ËJQª=ÑÛàÿ5kËBN¾&#Ñ¡B£¸éFCI+®ýÇü´ßïb±Uçd™axöÍáì)
+~ùòHTýñô¤„O(ý¥‚‚?Òµ°#Á÷ÇÀgkY„^ÚoíòÃÌÂ¼:07ôLL¬Sdä‰h‹°"Ð@Íƒð­zŒD¡1ì©Y>Qþƒå%ÈjjKjŒ•…NÈs½žôNœû¡€®(ùôOe²»7ºš{©ù^¥—W|Ô!{s¿¶`œ—p€¯ã·0U BŸ¯OãVnqËø _í×ñÀ¥õiÄcÐÿ3bY²¥9$¼õbð¹„ &Ú$’Ì~sûïC}Òù¨9ä‚?ùvåMå4+3æã’åýlbt Ôs!¶ÉŠGÈ€„Á1}¿½{æ3Ù’®O,‹O–If\9w3&Nq2Iyž©Jü|TÚßvÏ"ç>‚ qèÇÚáú²ðy.Y]Xolúøaédcw—ÓÈý{ß‡‚A€¶¢­¾H€6!á£½°a´§îÎ-™‰¸|0åøIõií{Yñ¥ægœ/v?®\iß‡„—òs¯]¡Õ†i
+êPâÀüJïØ#Z\ÉOŠvÎò“_Ë}%™å‚AKN#-Îì×öáîºðã>ü)ñ´xå9q¸dõÓöOÚËÚœŠ‰2uYRùc(ÖMwu®~Üef2—ÂV$ÜL1™×ðeÞ0%y3Uwé–æš;ƒÒïBz#+dü”sSu£ÒÞ¬6m¬E¥,÷£Ž»zEC/*HÓõSµ4œóž7L„;N’×Ïæ4Þ»ÎìIÑMiñ¥\÷¥%5ÛåÖŠd’«³’µ19±
+ðüAþú%øöß½üa3-i­žÂ%“fCl¥?…4Èƒ_É(<3_©¨h¢ÅÓWr“ØÌ"·Ñ*ä“¿v§'ÿ>¿xÕòàýà~ËSp¦ýÇ±>YŸÂ·m¦G]½K/F’×´”|AAÔÓho!"vz £ìYcI¦L¼£ÈyÓÀZxa!w€s#Q9°ÐhYü¸ÛÄÿH Ê	1Ã÷bpös3®‹0¥Ó¨Ð`A?âËfî¼¼Ìfó3N›gÍ"Yõ©œ79oÿÙÒÆ¥çŸse[8+ù Vxn
+endstreamendobj144 0 obj<</BaseEncoding/WinAnsiEncoding/Differences[31/fi]/Type/Encoding>>endobj145 0 obj<</Ascent 1079/CapHeight 667/CharSet(/fi/space/period/zero/one/two/three/four/five/six/seven/eight/nine/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z)/Descent -355/Flags 32/FontBBox[-373 -355 1170 1079]/FontFamily(Proxima Nova Semibold)/FontFile3 146 0 R/FontName/FCPYER+ProximaNova-Semibold/FontStretch/Normal/FontWeight 600/ItalicAngle 0/StemV 104/Type/FontDescriptor/XHeight 483>>endobj146 0 obj<</Filter/FlateDecode/Length 3931/Subtype/Type1C>>stream
+H‰lUmTçÞa™Y–Yug]°ø¢‚ˆ$)b”E‘Õ]W„H…j{¢?lÎI€œjÚ˜h“øq5¢PQTTPbÀ•5j1Ä
+™µç½kOß…˜6Içý1gÞ÷Î½Ï½÷¹ÏKÉ\]dEùÅÇ¦d.Y9+ekáoóLÉ…%¦9©–‚üõ…›ÍÎóé’–’ü\¥©*Î¡DðsÝû¯Â½`™7$Lhö›€>29EEÆb‹¶oÍÏÍû.ëW²‚tI¦­V]j~Aá–âÂ-³uóæÎÖEoÞ¬3*Ömµ[¶–XÌÁÎp1$\H|jÚö"‹.Bg¶l”É(²d^2Ù¥lÚYÌYŒ<1µL/›!‹—í“—!•O}N½p1ºl—Ëå¹òJWÚu¥ëG®®½t½ÞNWÑ=ô3—12'™aÅE•››[€[Ž[¹›Mé©\¬ÌQ¶ºOr_ã^í!÷ˆö8íñj²Ê¤Ú«:¢ú·g„çï={Ø6‡m`¿÷šéµÊë¯^ïÞ‰ÞMa¡ÇG§lÕPW#·…r`}ˆvîp¯cÝèa‹wY|²tTèä-×9Kµ¶¶¦¦¶ÖZc±X­ž=½Ó.m³SuàMà!¯ƒÇFõá0€¡–@D-†84 a1Æa/Í÷Eµ¤2jPŸ( Î jžEãÁ’ÑR
+Ò@)‡4_PŽ†0˜†«:ãˆM³ÊDi“’‚I¼‹¾R©ˆM,-qã^˜‚t7rÁsrãRøÎ7éÆú¶š{Úö6ë’Ypfì{;í!Âr»¤¥?¸©Žq††¿ÁCÁÏï-†^Z¾GPtíû¦¥_®3;QòÈlCßC76¶Vvjï¶Y“’SŠÞxÇ\V¾S˜¦(ÿó™²*­zàÙ¥ÂeIæÇÅU_ÌØòƒ%0K„ö—e¥>ð”êxAÒ‚Yýâ<)Ã<êˆ¤ç€M¡B\±×)Øƒâ®ÐŠT1ý Üå­ßq	—{Í ÐBÐË' €_`/º&¤½cµ
+Ý¢c™C©xXLŸ­¿ðÙUíƒ–¬Øå«V/üµ¡ª9[`;‡!ÐÙ*w¨%þêà‡I½82 èù0xÃ4}7ª¢–³øö”íÙ«åW"È;j·m<Å_é§Ïe'Ðbz ÎÆtAšÞ\úÚ¤ùzó·wvó'¯T_Õvwl\$°YK¤v‘:*m“ƒ§/Ld`Ÿô¾ïØ¦‡
+öÀe|êÁ]G ì”»º¿ÞâP‰0üÀ£<Å·GåÕ=w|ÕôH^8±•è>«Ñ+¼cÍÝb^ÝYŸ®Q÷H>p‹K/^¿›_¿7ìÈMMëåÝ¶+›R‰ÍÇØÌ­HÌ~+éËk]CÕõäëÞÚ¯aí²CÀì´Sµ„¿§IQþv“ËnèØò@é#0›p09
+æcÍD/œfÕ½ÛMÕB©©4tAÏDó¡/óxè€Ï9ã¦Ô‚•ÚØ„Ó.¿ùD<»G`I÷'Šðôé~ùè<‚ô¬³"¸4„Æ@ò~B“ï&˜HC£ÀyR"ð)2lW™I"D‹>6Bƒ“ ÒJýÒæO˜ÐÕ#>Xa‹ûXPK7>¹Üú­fpé7ÈòxŸ%ã Š¶“33ósÁ:’ M¡~ùõ)Sæ
+K^‚ÀŠ¤%NN¨ä’ïNtn÷53šéTkÂú7µ¨èþ1êžSZ0ÜL÷eFÜF–ŒäÔ¡	M@Þ&°0‰L¦I¤œPÄ#YÎ€üIG3 ýG³€dOéhç$LR@P_ rè³p:ìû¯³uº ¿KkE ˜‹ø˜d3 :Ö2ìRÐºÿ1"Áê~jü»vˆaóXbÒdb6¦KÅ©dTÜ»oñð!véÁ8]QX`°.Õâä ïHuòÝ›æÌSÂÐeº'=üúÊc(ú¡…¤¨'ÑÏ‰PY:–å0q-ÕŒiaf%C%*_…“s0Ì°Ø=®e¯:­6ˆÔü¸ód÷£k\æ…öÒ.-pC6˜-HY¨t¬QÄdc3r+ñlý]H›|AÏà9x	G “F"‹Ÿ¢Û1ó×:i6‰4¡ýuL)DÄR»3,ü‰Le„’3i¢†Qí8ªE.w¤ã2)ÆEN_ái…rôELRÍ‚ÿHà¹Í	_ 9
+”
+hT9ÿ”vPÉ?ÒJJ&D«¾ü1²Èò‡@0‚‘ð!³È"ûhä¥ë¾8uÁtÔ 6ÌNÃ?‰¦kžè‘çÙc¤ì"ä“ëè8¹”Pq½CDúé7†P'àyFÒ¢…K0š–ñ¸ ò`s«ÑD˜þsL£¹ÔÏA¼yóê§•üµå÷;ÓnÐ­í'ipÿÀýZÊïVmY/DD¾ýpýn¡uwž–múX)Ã´.„ýtß'÷ˆ´5{Œ“y<?Ö¹
+pc`ü?ÜûÇ/Ø&PÁ!ráUr‰×ûsÀKoß{rÀI'Ñ¥Jˆúbé_Z4Ïèºm+^ÝÂý„nKZxbºg†¡ò‡‰V Š„û%¶íÍ:KÖ¬àØ¿6­åÙ÷ÇÅv8ïÛ¤ªR;d‹ŽÏôM:©'«(õ ÑGà0âÊa¤?#÷m$Oîw‡^áŸrtMéú'/éÑ]Á–ÚßÉ˜1Ù+‚¾ÈÀ˜ìMùãÕUÅÞ{Ç¤§øšY–wö=E­ÃˆB&:º%¥2.?Cê¬4€$DÆŠ,XP¨5H‹À¿¦‰F~¨ ¨È±$t•bC˜aµH&ïc¿³µ÷´§öì{ÎÌ9ß÷æ{ïÜ{¿Ÿû¹Ÿ/Í™É6'~%³üÄÂP’ˆ§k÷»ÿd¹4é†<h—wÿVÞ­r–A*¡–ÓDÀ¥—øèdöÄ*)‡boÏ ôÐ´F)•©Á›&á°†(ò(M‚I>	|ŠxÓ`$7È!2Aá*e{~Vt˜ä"˜dhÕÐP"yQÄ[ƒXHXä5”:½(öýžk–ò”Íj)ï>™¤Á.%QÎ7ƒ!vgÅ¾lü|S/¬ýü»;-?@ªƒË‚ŸÔø‚µ¶ÅûégÒ#tÂ©uTÓ_OÔÅ÷[“tâz¦)QWñ<ÿ”QŠ\›÷hÄÍKg+›…ónÉ»¶íã7Ç×Ÿél®ï±¶ìM®ÙƒFÛ¦Li‰B¯: æpYWÕšk»ÂÄš»Súx˜?f‡ X±òYð¢ngT‚EÆáüP:¦±òLMÿUg¨VñÜê˜È“"»Æhƒë6ˆ
+å§ð¶Š,½ïKíç>³Ö.Q¯¦½jx‰ØÒo·Ÿ¿òÍióž„âÀ%Êšþ™–'K{“%¿ý@æ.ùªÓ~RDwl×ÜÄ•‘˜$	ÓÂ‚‹gkZÍÂM7ý®¨Ñ|`D¿ÍÞÙ?ÜÞ‘ªÇ4wGàw×á‘9*8öýL`Z˜³|†®UY[…Ø*)I·ç%~ÅÖÞ/rEiî1|—ƒ’øE>¨+½È‡ Õ„åáErŒî)n¸Ã³¤
+±ÏÃœ$E›ƒ³ÙÔ‰¿7þØ	ºëø‰¦òò¼·JQTQœ­43å½dÞãf2GLòûÃ’¨PØ ÏfœÉÓäàî^”EQÏ…×QAÌÕiX'r·¤m†»ÊtlßzòEž,XéGV`Úþ0¿¯»¶Õ,na–­Ý±acô‘–íªèWTúŒÈÔ¬ÂE›­óâpÛ™T}¥ÈæTÌÖTGîPJ"¢i‚þ6²kQpØŸvà@ÓüËÏw˜ºcÖÚN¾Ç’"²hd0|gXØj2×ÁM"ûõª««S«õ‰)©z}MjƒÈÙ"½*‡dÐàÐŠ•þþÿ˜t©4Î¿Ðá)»ÞÜ_x0WÈy‚Ê+?’ÿ1ÿC×åû"áúoxYX)yªÁ“F­pâ`'EÔ4I"Ù”´Ê³šé Ø™ÄÍW]XAZxÏ•³Ñ…nüánM/Ã´¿§ïE·ú¯ß¸-~§Ð¹/¾q=¿nclŠátEã48î–¡öãSuVþ\eb¤HÐ~Œù¤¢¹î4V~Ááù5N;ÝÚ°šg¿ W“k™u5$W´ÊZÛÅ÷|šŽ=ðŸZl° lò³ƒŠ\ÐCüˆÖ—0D âa@+ÚÜü£G¾n½Óòäªè•x% «3!Dö3	Ü]XKPù1‘–î´<xŒN`çøÛ‰G˜.%V@º‚ÅB$I
+éi•6"40&²¦!C˜éäê6~¸3tùùþ–ÒaôÅó“‘øÓª×Õ„aúkI 	õÝ'ÎXDRÄÀ°[bFdŠ¿~»›p~$+öûÉ9^Îìb™¸ÍÔWôÔ4ó¦’?ç§˜°-ú8Ô|MÃ°ÞÆa°}¥hšÝ¤òxŸ*¦}ð5ì
+õµË_½¸jõQ1Ük2{Õ7|ÔÝÛ•ž\-4_§,ñ/T¯á	ûì³O‘9ßî~]ìÙß‘õŠ—~GFXXh]C^Mx }ãŠQ‡’Œª¶OLG?ÓoRoæîÉ5ð)ûªêDx{<5Ä•Ô2A§âo	¬ÑEK†Ÿ||ä2â¹2Î$§Ç¥Dð›*E8§!Ì²Ž?N}Ùk¶4lp<¼Ôe™/á$‹DáCC´d %Ï¦GÉ8^¤ˆBv}xe&< ’Jñt%e«á74<.(hÎäC¦S”8™òÁ¾†Ç¼ÀÒ\"¸ÁŠtu¢XÚ«”æªá!šl€B#EpM“@t(¯!ˆÉ3¤BÕaÅ“(Ûó™ÓOÌÆÛç«Ú§¥8ó;åÕyåü`áùãu·![ê÷Äè;Ä8³wm¥vdï~#™çÒŒ{çˆìâ‚1èWX%NiUKÜÉ§á ªÏ!ç|?ÈeH.¹L±).-@ÖhA"…53ÔÑ!…ü/ê ßÈdCsÃÈµ×tËÈt{´ì·Þ*oP¿¦Z†F¶…F'/Û´ã‰1ì~“d(í.u”€Û4Éü ¬”*ž\UVö“ûÜ÷y=˜×ÐR|ØÝýA‰ûÃpàéKÕ¿ <U9•
+endstreamendobj147 0 obj<</BaseEncoding/WinAnsiEncoding/Differences[31/fi]/Type/Encoding>>endobj148 0 obj<</Ascent 1079/CapHeight 667/CharSet(/fi/space/numbersign/percent/ampersand/parenleft/parenright/comma/hyphen/period/slash/zero/one/two/three/four/five/six/seven/eight/nine/colon/equal/at/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z/\quoteright/quotedblleft/quotedblright/endash)/Descent -325/Flags 32/FontBBox[-356 -325 1136 1079]/FontFamily(Proxima Nova)/FontFile3 149 0 R/FontName/FCPYER+ProximaNova-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 76/Type/FontDescriptor/XHeight 483>>endobj149 0 obj<</Filter/FlateDecode/Length 4960/Subtype/Type1C>>stream
+H‰dUPWíùt40M™ÁT6jD‚DQ@Ðäç!‡pDP“Uü$îvË¨IULIÐå/•ADù¹˜AA"8NíÉ€FüEYo“K6Ûh¬JUº«ººû{ÞyïÜÓ-"¤bB$)#ÂbÃWÎŒ5älÏÐ§Fçä§ÎZ©Kß–•jžÊ+EüD)ïéÈ"7=¥¹¿ô’àãÑ.ëÚîé-'Ä"QÐ²°œÜ†ŒôMy^ë¦k×ÍðŠJ5dz­ÊÐçdoÍÉöñš;gŽÿl¯¬,¯— ­^ÝV!_—6Û7bÕê¹:¯@¯4ÝF‚	'!%JJ8ÑG“D¨‘Az‚È!ˆB8âé„71(ùŠîˆÝÄÑâ¿‹[Åâ%RÉ*É6I‹Ô[ºVZNÊI_²‰ò¤VRÙBYÌl7ÕNkwÀ®Ò^fïkjŸmÔþ”ý£	®tÊ\š®;Ú;ú9«ÍŽ¼Ó:§§çt(}”îwvÎs®p~âÂ¹ø¹»˜\í\µ®-®äKä;ägäß0³†9Î˜Ü<Ý>tûÜí‘Æ¯zôDµèfOJnú±ð|Ô†Ï)0ëÙ_O qô„ŒÆ¯éc¥ù î„¤ÐˆŽóÍØç~™ê5	$õE'‰êkH"ADí ½¨Ë !£©Ô(P2êõÃûkI (5&	¨ñä©hT“W^1I(dÇÇ`Ÿ@GÃ¼Ým;ó¡¤½¦¶·ï)×tCrw¹	RLÌùÎþ0;ûjøŽ¹Ðù°o`ä¾Ú<S%¼÷Ñ„ÍR1ùÆ³)~ñ¨/¹š0ø9ÎaW¤&ÆÄnhëé3¶šº›ÞUsBÁm{Iôà‰Ï8GÝÇ±1¯°Ý/±tÿî+ÙùüÿLò†Á£VX2Àù³]•=Ç;#+'îÞ¸5&}õ–ª-U¹5ÛÊ²k·œ²j¾ÝüD1¤9ïÏ1­>¡ê¹ëJªTŒ185<~ª]F¢€ì©»ÐÊ1y¹å†/wØýD1Æ¤s©iF;¦+x{©©±£¹nË»êèMKÓ¹¼ÆõŠ¦±L–1†G¶ØúÏ»êTåºªôŠÌ’¼Ýi­P§Ó­ËY­¤ùþŸ‹
+ä@_dÖßçãÙ–Ú†K—­úŠÍú<C6Ç”ê¿Ì¯<x¨¸øÜÌlmf¾VLúÅNÔü­¢0‰=WOF‚\2RÀ;@õÃ%×‘~è’€~è¯@ÿvœ{¹×•@¥4`1H‹2Ê¹s›ÈïÁ¹æ‚¿üÀo¸pÉäUd‘ÂwôG?/Èÿ]%2,SúJç}åï:×ÿAçæì´—:Ë@×'ª†ý’jÐ±°¿÷Sô‹ºA,é>ÇêËÕÕeeÕÕ†2½Þ`Ðúª
+F×ŠŠ UR 5Q°gt-KÑ»-üi‹¨}F†%íp›ÅùfŒ„HÐÜ.ó! Ô¨ÁÈ0Tc Ç/rGõÈ!ƒÌzàÀ<ÎÂ$`€9‹“ÐC˜ä¯¥ùü¾X] ‚›"Üm£¾¡Â"qI[Â Iú‹"_nñ‡%ÝùdÞ¢ ¦	d.à© ${P2ëmÝò®=žl;s¥î–²`ã|”¡;Jp?Æ©èv[à€ò,r~–-ì[f¤ê1c´%©„iwAòbvGôAó´ç³Á@Î¸ŠnÞÁÉqI\ËZ²³õbååà5mHðÒÍ¹YEÅ…ªÅ²âOkŠ*•ÌÈãk›ƒc“ÞZ¸¬¡#MEëE7à©u¼žÙ+<s·Á¢û7fñ‹¢ðÌX2f„_ Å§¸KFÔ5ša‰EtÇ§m’¾¬ºÍ¼a\œâ§!ð„Ioþ%ËWædfªà¸ióÁ1Ùå|²ù\[‰Iy¯gÕ¼ QsÄìJQÑ%Ûi3¬<²uHðh˜EõuvíÍïžL™qýCâÞËæ>>RtøˆÞ0ÁÀœÉÑÖqMWÈóâjý•€¨Vñ3‘e#ƒ½Ñ.å™mg:ÕkìSÞ¾öÞ½RpïžETÃ'IÀÉý
+Êùä¥±¤@}äe«È;la68;2ÄÜí€E,R/–ÃDa>âw_,ã«õ¸¹í;8¢C'Š×ìãÑqÞõDë6Ž¹hX=WÁXy7°²ASs7ìç´‡¦T*ú{ƒ·®nˆ0Ÿâ56,4eA`h³ùÈNrÆ€Úø¶‚.)´À
+3=Û:V›d¨ŸMjú*sX	1CËA³0ÿ2Ï[h™)?.ÇaËW-Uªâ½E{÷*PJTFh+38¸lì&V­ô_Öò¸§ý¦°ŸÍÞ‡TãQ‚Ú×qâ—ý9Oc
+éŸ3
+é0¹STÅGIªøé,Õ9EáÇR>ªC¸¡!=¼è.øw×û0¹N^_÷ìúoÄÓBâ7B]H€o3TXc1”8	4ó‰Æ+ÜŽr2cMô¶¥JB'áÛâ1‹a‰‚«\DJÚ–ücuŸ)þDu	þE.£˜'…»¢È³ÛSê5Jœ€ö(EÕ[Ýê‘^ÓéÖzUñ‡dê?O¦u)‡î~~†r˜"DK˜Ó0#0KÅ'ïbS³’"”‘ºó½*ï¡õÁSíú¬Ï8ú¶‹é^frqdÔM°ó¢Ð/x\øßxSXú«/ùe‚é$|O1#¸ˆcÁ{LFbE_*ú?¡ÕÕu…K†{¯‘zÍâ:“”kïÁ4øÀ`\cP#>yˆ<¢U2#>#š cjW£±¦ÑjŒ5ßõˆAå%(ÃŒ<”HPL‚¡Ê>tOÖê¾ƒØÆÕµúgî™{ÏÙçûöùö·Þ³Ã
+»gC3\my½EzØ`€2Äëu=Mu“?W%V±«´ô[¯®Éµ8@Á"¾sõ°æŽ3oÎ™m^`Rq>–éá=X$HoåÆÌž¼`ákªøOÒh•J‹ŽÉézÔTz£TœÃE-žjž £7ê€##¸ƒwãµ·¢O«µ9œcÞø2$ñhÄDLz9!»Úcwkhf¾-:‚¹–3ÈàQ‰2ø¢YÅµ|³ó®ží_Æ·á ôAï@zŒUÅû¹RZÎÂíØC »ìØEtzìÎp^L¥T–ýgN3”ýò;¼ø¡,vH²^×˜±iÍ}Fm†@T	‡[[ÞµJ>ÂªIð*,_n	•qqåŸpÖt}qL®Zý5W1¾Ê…däfâh$ åäYV¦W³Žh®‚gœ^p&äç f(g^¼ˆtæ½AÖÇ(i/Pº"«¯iÖ}^¥É+K¹.ƒÇ÷WÁWeI!ÎÅBHlÔøHËñÌUŠxìÉj–jèæñtÃq¨å¼y,ÀN:];¥578qeýîãØoíx™Ý¥Ý`=ÙS1¸“äèûÍÒùÞ¡ôàÑâÜŠf¶•Ê¢ð$ÇbÒœÅÜ)¬¬˜nSCû·gBoh"Îƒ¼s;È¥5,“6ˆé—û°¥/ÉñÔ‘†CÄƒ§ßx¤'ÆcÒ{ŒWXƒFÐaûcÀKdÆA0ò>ÝÀ¿ìg¤"~AÉÝg‡mÚéBE‹ë€÷Á,^¨¿nàfº‡^*fðLÆzSLìÃ`„ñcMêSz¦§1ôc¼V±ïÄåÊT[ÑÌ«œ­òdK§~‹õÿØ¤Ôé–ùjàƒÈ„û>\ê’ÄôYÌÒ ÖÁö~¨ÌbèäqâÚ¶ßª†_{ÁàÑ(*Zyk$~ÃCh ç¹@ozwß¥¢¼*[t§ÐÏºt{!aZõ`ÄçN¡Û1uì‰ûk¼.—mª«}gn‘RTÁ•GO8å+ãóþ&êÏƒÇÛ=Éjë»7SC½âÏ@À°¼Â…Š¸©¯IÁFº_l44³»°Ôîüt,¡Ò'H:e‘´;õÒf„po{¯*lDˆ3@@1|"ÆÁáõ *, D[6·MÑÔár²Õðw’'hNö/ecª³SYýáÊfÐrÍÜÝ{_ZÍnîòE3ƒ´™~Îd%ÜTi8œ†Aô™¼fù±LNlêáÎ^AÇ²]<î„vøê¹a<ã~L€ý4„MØ€»ð>÷€‡eÍ‰û–Á!b|ˆô“ÉÃLÏðhÆËä—i{œzNÜÕgWl®ÀÀÖÙž<ó`Ü5gê$æ!8=œœøûô‹iið·‹0¸Ê³ ¶:¤ulÁ·yxvlžï„Ykbb•ÌX.ïl~†M®-Nš®ŽÎ[æf„ËãGÇá¯T©ðwßÍ½UuéÀ¹3J¾»yUœuž<%á\Eeá¹Ú’Vó1Uü4½fY3Õ€Éêép@Iƒ´ÎapðRá7BBVùÒ«2xÞi§Æóò+]è¹bžE…&Áá<©‡d!÷pyV¹Üi5#'øGDœÊ]£ŠÓkØ³5nùº|Ø GŸ||Z‹³
+²•ø<nÑŠ·¬ñ²ÏŒ¦žž+ÝE_¯]xB-Êã
+’b³‚eô	 EyÿV~”hÔ_38zƒL¸ƒ/±Dœ ^)ûáËÄGÝžWË3³”r÷ÄÕ‘ËæÈ‘==¶¦ŽØ–$QÅ?¥WBè%Sé–ßµö>`#º}¨µT.(P–r–ÅÑ©seï7Ú>R™ü%¾c€'sVüC£ë!ZÏ¼ö‰Šµ¼}Ë…ïºesIãcªá…J·v‡®Ýà`c:«ý³ùŠ#§
+÷îÞøçÊ—¥ÜÎµk¶&Ëã¢£üÔ¤Ðð&Aü+ÆUÂjæ^“îbWì:ìøœ>º¬ôý[2÷"­J7Ù2“ u¼.”X"ûøŽÀ y'P#›Mwƒ©Â‹&KèÔ7÷˜¨³>qMd’Æ½áQ­ÞÅý°*Z3'ÒÎw«CÇ†‘„~àÎ+özx¢™nWÛL?9à‘s¬4Ë&W{‡"vÑ2«õÕ³òA°Cz î¬BôÀ£GS¾J^’šœ| åˆ*}Ÿä¬Ð;˜ÕDm§ãªØ¿þÿ’Ó¯êMÎ#üì•)Ó?ødËzeýLnÃž½›2ä¶ï«b¤kgX¤Ö±á†vWÀ^XÉTÛ¸wpl–±"45r.¤ZÕÑd‡K!TÿtqNwIz¥ÞvH7{5Ú?ñóƒ§L_°pµRôAâ™Iòäéq+­$¢Z“Óê¤›ZgÊ—[f«xÓ=ÂéC%YEråz!¦ýWä-ê_¾öeóÂ°0W6¥óCÕk¡Ž–R}T]MÝÜ_`oÔAÝzüîQã7‚1ˆn‡~è¤	÷LH­q÷‰lý±ÓÖÚÝ]ì?<*ØG%ÝŒK“¥oÿâF©p¦v19¶•Õ2H­0F·£ôÆœ¥	KIEßP®HFl ›¨7F†DDdå®Q`•V¼™år‡m‚ñ©Ð%É6RhJ\¦Â0¡piDæ}*…#[ýAª²¿˜£âjÝIzK4éQYÛIzK5éáÊÖ8ûz­”íò•kp_Èùêòé<yçgÙô™Z/„G'ÅYT)»Á$ˆÆô
+¦¯pË«ƒ´:ÝÉ+úØÂšwÿMvÙ†4…q¼1ï½¦óFÞ®Œ]Ø¤/Bú¤ÆÃìCø’†ÙÈ§`[¾ôâi4ÑpKÅnSZ#mî:I{·0§%•µ‰ˆEJ	A&Aõ9ëåÜ¡aôíó?pž·ßsž·lßýØÑ³Ë­Ëé:ÜõPsïŽš;UæÓÞP·JõëÌde§'}ªž¯ÑëžÖækŽM{3sýCf²ìö[§àWHñqV	G­ü}¯óŠ[Wý„ªo°\SÝõAŒ‘¾u:V“ÅÓÌ¾Áâ-+F(dYOvœl¹Ö¹aLIeÞ‰ƒBVQï{Ì¤ã%fû˜áëë7ïiY½m13r±ÕAU”0OC!²Pzyü$‡q
+J¤v“BMµ}Ù#"õgòUr¬¸Ô@‚;‰4æœ8&ÌcŽLlsÄŒ!f9[(Ê2ˆGjŠM‰´‹ÂŒJ¤NX¤q.ØÉ¼·RÉ4ÖàòÉ!&Ù¬ø ¶SÙÀ@±z\0U"®&¯½ñŽã­û)n¨ÙÕ{©[xiñú^Az£ÖÓ^ÇÃçÍ”±¶ºÞ$pUÖs­íõ:6É„•"€¢”Ä½4xà'ÙH7e‚›ÁnŒIŸf¡#ß€µ(ÆÇ¿+AXÕó…¦²¼\ÁW5 ]ëñIO¥¶©±¥Ehõûnû=Ñ°EÚ(é!q]Òæï“%lvÀ6B™ÉøåYÈÑ3º,—Ú1Ã32ÝÎ¦ÆN­{â_3ÜA2 éTEØFsHÊÖ¥!…„$¥¥<’Ba‰–]š^Q +;´„òùƒÏ5#å^SùÙÓåWÅ¾ö»ý²¶Ù\a4‹Ñ`8Éÿ•Tœ!Ø×¶&©”%ì'²8;V:!ª›Æb·ËÁh=©).×oÕf›*Ö3ë÷¶µ«Tsª8¨Ý†¦ù? ’®f
+endstreamendobj150 0 obj[152 0 R]endobj151 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj152 0 obj<</BaseFont/IGANUC+ProximaNova-Bold/CIDSystemInfo 153 0 R/DW 1000/FontDescriptor 154 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj153 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj154 0 obj<</Ascent 1079/CIDSet 155 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 156 0 R/FontName/IGANUC+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj155 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj156 0 obj<</Filter/FlateDecode/Length 1406/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»¢ƒ3[ŠˆY$B|4
+b¨Rå¡¨ ‚,°Ùåµ¾ÖXµ¦D£?D@µÈKVåM©UkPk[bE±Tb}64Zïà]ÓÎÖ¤úý»ß½9÷œ{n.I¨<’$½c–EÆ%E®,´”š7§ÇYlé³[ò2Ý¹Y}Ê5¢<”µ*YÔè\:—ÊGÕôúí£êÕøÂjOØãÛ5Ó}èA“¤š]–˜™iÉ0Ådšò‹ÍÅeQkY¡9;§Ø°)e¦aEza®!Á¼Ù’_dÉ2„†„„"óòÿ
+ME¦B›)3Ø¸4!±Ìj2Ì1dš²þÇOy1‰à-¡'bˆXb5±žH#6&"‡È%¬DQHØT=Aºkµ„VÑKL'ˆ"¢‚"'“Ád*¹Ÿ|í‘èÑîñŒ"©ÅÔ	êÊO•¯ÚŸ3»~¼¶ž¼Ñ ­”6[7>Œ/Þ3p«^‡­ãµÐªfñû§898²ü 
+¦SÍ0¢Ãˆ_1 ~"!"Â ã1!#0B”õè™˜ý<Á³åÉÓ'-Aè)²†jÛ¸ÑNÂø€‚çúq#Nb0³ï†ƒÐ´«”aï•ƒ—¼Pé&û%wêÁXÜã?@=¦ =„¾ÁæˆXñî,º«ãrý ð]þªy–âL•PÅ°wªm ‚4 Wnçàøò·å-zGÀ+LÀdO¸ÂhTÁ-¨Ra´šÑÐ@³¸ï-ÉàKA¦›£ï#Ãæº§Ð«poPþõëRºÊn
+0íùO*É‰èëŠgb3Ò—§škOˆ,Ì/‡`œâFâöŽÇðV9J‡Ç4†«y'.wÆòawoŒ4{Ú1ù3øÝ}Á5‚’€ç·ÉÅz¸Î€äßŽ‹­Y)v‡Óç[»O~#\kË]'E3rãO}$,É@Zâ{x¸æöÀ¥ÚM"_¼–á{à•Å¶i{†°6ãLGgë—½­_m·TKìMÐþcÐ4DØ•~“ah•~§Üjµø9ÓcJ:/ gH †ºÃ~7{¹ÿL×y‘ßçFQå–l(Þ(D­½4|¿÷Ò­¯;Šsk$öœcT#¯ÆÜ 8¦ÀNðä_6Â^
+€ƒƒ5=bÂ=zsÞê²ÿlÞº¾«ŸJ€uj	ú‰üKœá‡4$8 Aºûq©$Ü¥î>Ô|åŽÀVÛd»ý¡ë… ””1)¾ôéÚš›ÛÚÌÍé9æôôsæV‰tÍÕ§“íÈ»ìûÖÒà)ˆw‹äÝ–^U ¸1 9%ë¬ù¨3“¿ÿÃ•¦¬<‘¿=à žá;àælõ…º^áÛsÅÑv0l†ã9\F:•%Ÿ,U= Ké»k¹/ÀÔÁ£ Aªfn•”Taª¨ŸZW¼óÊÅÂ¼³bïoôù”ØºyòK–ÌGæ•}x«tqg›Ã<usAiâÇQMM9"‹ÑŠGF›¬Š{ ˜c…‡®¿¹òøI‰wZŸÒ»w—í.,[kë%ÈÔLðVœó^€ÔdxkXwê¨È^ý×h™³ÿ§°TQèŠ¢‡KI¦u”SóƒÈãSfVïª¿î\nq*+TÇ°{1èpÛø;·G®á­¸JÇ;?«jÜwLÞí‹–‡`—¯xã45r8ŠŒÒè£†d×Ž²ºÀQ²ëÁ±åÀÁ’rHvB8ÙáT×º4gV{»ÓÙÞžåLKËÊJY÷%ž Kÿ~ºƒÛqT¶¹xäe¨ªÔh«ª<ÂˆÕáa••kÞ-×LtN ýDçÅƒÇ5ÐWjÞƒCZù˜î h¸
+endstreamendobj157 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj158 0 obj<</Filter/FlateDecode/Length 4282>>stream
+H‰lWK®¹Ü÷)ê]"“ÿ­eÀ+Ã0¼ðì™Ek€ßpDF’ý$<Uv±’ÌOD¿üãëõåï_Óõ—¿~½é^y^øÛÊ•¯?~y|ùÛ¿ÒõËÿ6ëµ®§vµÕn›×ÿyü÷ñû#]=Ú³­{bI˜xýïë78Ì£ÃakCä+á_¾zºk1økå.¹ÚõñíÁ7ßv÷Yðôz”;»žéNe]å®æF^FoFíãúÀÂÕ;Í1æUïŒç|,×³áËdÁk)W|Rîæ¾;œÂ˜9»»Úóõ¬wš\˜ë¢ac\vÏýøãÆãëñ+u§µ@|!ó…]S­Û¬÷*p1ï•û=Å¼Îõñè8‹ÑÌ6®8ËõwG$gÆº‰Ð2-ƒÃy	‡ínø{èàÞ?ë.#{X(ÍÂŠÁ\,„zŒìËÜÈ·U¾ñoÒ]ü›¯È²Mßo°*uìj=r/$GìHLÇÇ’ä¬à ®ø<iGè†T³
+_U|å/'“2qlLÏ'Ûl¿zmó™›ïüb¾Ïó¯èÅ~ê­ÑØBØµ ÃH÷i­§å;µêÍõ4C}ñÈ‡•ædúÃÊ86ƒÞ¶ÿgñÿPTJ¹1DÅ„Ê¿,vˆž^ün=,¹ŽïÃ÷‡Lý}…¥ƒÉCò<VGŒØIÿ};? Œ„ïëý\‚·Á™í&â(ðûÔó3Ÿ·lÚÉàd"}mGah›‡ÌØëµÍÁV‘C{ÞòÏ¯ýãWç‹N|îé‡h?¼Þ`$ˆÊ ‘»kª—Nô´"¯‰Ÿ{¹Zõ–þÄ6$Ö¾Íá]Ï®Î=yFo~^q# c|i$ƒº7ì5–‹´5RÎ5•]žE/#¹ÑØ@i_+L´wÇçÈ0q]eì` b	›ŒBnHéœpÞõH·ÉŸÌöògÄ„sýhƒ‡Zboq=Ðó“MP›l[N¤-9I¥áVê•´4óò	¬ãnÝÉÙDZV˜ÓÄ#w ˆ»‹35£CÒô!Œ\ØÞ3{Ö%÷þN²ÉÎgs2j2:ŒZsXêvV*mz‡–áHq£®þÞ0m>#˜®(Ú36K_`mØ#ª‘kî<ëO¦SGðnŠ¼©ßSS&%¡%Zmw©¨ÿçF¬ƒ™1ö
+Úmy[¶¼K §KŒäMiŒ‰ÊÉÑ«dØlê°<Ù:…uD»GWCŠÖ»¹q–FsÀ•·¢í†k÷ªd÷d*^îìûìu-ÍÛT†z¶•¢u*Äs÷®O9¿ëSë85 ÙeÛaõ.Æ¾äsOìÑ0UEÃáp^`Œì„Ø*C­Q™QK|4Nµ1{…dkÐÅ‚Ð¯hohö,˜ÙSláƒufe¼MY+à°c¤{åéNÇW£Í[j.“´˜xËTêC’fFž»ÝñêY2ß¬pÐk	“	´ŒžC®ÒFá"A“ybàs¢Ê¤˜Àm®`ŠÊ	œ†ÔGcÈÍŽa>™|¡Lç9ñ¢[NDÅ©²o”<PQN PÌ€LÖ¦#fGI{Ç"„2JÒ„YÔœž©üœSwµ—«7²­\íU'«zØ<žÈû)R¦.,U¥!©>yX$F¨=	†¬bV5IYM:2ïo2<ŸkîÔY›d¨#“zçm·ð0Þ»·ä»²qKïÃõeJÑIVÜf£øø-Ž€é“yÔƒï¦–Û¶	èàJ~‰>%çjÀŽ”ð‰®U	0°¾+f/ëÂY¯1"’W`1qAú"Àr²SA'ß›ä%Âß%sCa&Ûï"µÄ?žÜENÅáè™$T)‘¬ú©Kõ1ažðÑ\C™r;ÖôY¹ÞìÌ!Î=Zu‡~(²,EnªýÏ™{@ãRÜ!Á8Pû^CÌ4ÅUeôÂ{_ûú)¶ö`—ÖÔâ„ÝÔ§Y—b6–xk»-·®ç¨?ÛP>-ó¦áMÑþäP·ëôjðFErR÷‘ŽŸì#d˜áù>¿­èðî“hlCiº¦‰'CKÑ„‘©·E˜Ìêb=wlÔqjÅ,i~—WÇd2íÙ®jNæd	~D-[€MkãÝkÐ¼0%Ž¾¶%ìy+UX•x+<é„R—h©oœkŠ.Ý6m…žÙ”(8„AJ¯‡N‚Ú#áäýúnRkÚÖäÌ¶Ùï(³ä+e’í|œÚþFa4zQT«qª›3Ç ôÌÒµVÞ’If Ó¿IT¥{1£k$¤¾…If¡R’…T¤¤ó¥`tDòGQíXXN¥ƒèõé•üÍtÕÿtE Kiª¨-Eª¦/¢Ö—†ŒÎí•ãê8‘ŸŽ&°MÕcíÚËðŽï¹Å±bÚhª+ÃìwŠ9ÚÏ¥ØY•ý&'‹4ï‡à|šéÊû’³‘`ô²sW0A?¤ÏkA¡îèd$§üŠ³ÒRwu^ß!<¾jy4ª‰ÄBô¹z$ä¦ñbí¥ÆÆÝK‹õ>kF„?•d¦¯­
+8ª¨'Ú’Ey¡¢|eØÎúîyn/¥Ô½$D.b!;MMXµÙÖº~Ò4Ûö•‘ž+‚åD-q‘èyè";d%ð|fËùÖZ¼5´´¤’=otlõÌdÉ–q	ÚâZH•4&9ÆP óŠ#Œ˜nÃbÉÆ[Ñ;«Q?fG±mƒÜ(¢	O¿älÃt)˜N$!†ôÝk›ûºl(ó€štõÂšŠYh=\+ê–OìíY9ÿ ‡¶=X5†#/õ÷ÏAZ1­ÅZÁ?ºþøqr
+Y5NO™„,/¨kšx‹ºö¶Á÷Œ‹†¶'J9ú•KœµGŽ6Ù· ù¾ÂV©Œ¡»Î´ëËËd‡¿h’ÌÕ<[8Ó ¾Ã8€•ú\_Q?­½¯8]psñ[ÌV>'î~sT'\Šïˆ˜šk§a€aVHŽN
+\v$¡3A¤ÖŸC²•x£+¥D¿ãBj‚	U•øX¬ #$WKêLNªRæI-ˆÍri$nÂ¡„Xè”ø,ÔBrÅ¡ Ò…†qš@DÚ¨)¢>,Lgúæ×,ÐÝÂŸ`ÉŒÁ}Ñ”]û¢¥2_«ùÌU÷Ñ=ˆeýËÁYïêÙüBËÙ†”‡Ö†–ï®p¾Á¢íÝy[¹ú4ÐtsPÏÅ«p†y²)d§%NžƒÙ¦HŽ‚ª‹–‚Y—8 ©Ícòã;;h/Íw±]÷á ðôçÏÄu¥ãAüYœö›F8Gé£ù&	}‹vØãC>Q•4¡Ž%!¨ëŒš„so¿ä·ëú3W9¿½jvBÕ2UBB+Â“k- '7•sø‡r¨&ÙÔ¹i%Ž;Ý¡Â ÒÙbxÞ#Æö78mH¹nWÍ+¢é…#aÜaª³à[€Æá†ØÞ‰Ð|c:x!•`QÒp‡k¢_|­cŒ1ô4‹”WÙóŸåï'½!ãž+ô§ýðùrã¶¾å7ŽÆ6ÎO8üÂç^¡aö¥"¦vˆ `]ûü|;ÀeþfÝ6Ü˜¦õ““åV”ÙDöÌõ,±Ëx™q}•xNõ]Ó<HjdåàÁžXàì„)BS©ãv6½†q/ÄR÷VÔƒ¨{'Aµé†ùÎÿg½ÜvÛ¸0|¯§à¥TÄÎ’Ëå(
+4ŽS¤@ 7Þ"IÈòÖV+KîJŽ“·ï?3\.år¼°å‘¹äpvæŸoHþ¤Éãº«‰ ÙÁ‰LC",¤­zÀZò8ŠÎÄLX ÇÁCz‡®yaÕ0Q«•ñ qc
+ˆ¤+Éøjxœñ.§””˜Jb&4Ã&˜øâà’#JT%óˆÿœ‘	HN!E©ãÂÈM5·¨ŠÌs4)[RŠrËÉŒ©¡G!öª°O
+ƒ=ÈW²i¨Ž±$;”ëè46ä:é–”~¢óRQcmßÓ»
+w =il¤Þ÷°I§*¨ì0èQÚûÒ™oR=™‡Œ9Y¸y¶<äŠÞd¾F||#a’Ž©erZ§›Ø«Á–ò\M½¦EÂ¤â¡@…Ña¢¸ÈÍ\ 1qTÍPóY \ôil”°¢¦iTð‘üuéoiSüÞEwëÓ"F¤M‘ºH£“„HGA©Ž/ƒHÍÐM™ˆ¡x ÀU4QÌ!ƒ{»GKs5˜È]›1b÷¿¨ã 5.vz=	úO¦I$1é0ÓÈd)£e»Jm)‘­´* ØR`vd¤7ru-I±åö‰kåï!ÒbI<d5ÏŒ¼Œ´taºð£ ¼hRùî•ÆEèbAØŸXés	72=¤ñ‰%¤è;ÑKÔ,šÔÕSöŽÓ-Â5yßÕ$Éô=[ãi’Þ40Ýÿ"ç?09°PUbÌa&Í²õ L’]6Þ›ÈNGàƒ@2g¢—LõÌQ\÷bŠúUJB(ânX!¨5DàašòÐ”}”¦ÂWÒ”û"šŠÑ”{”¦ìHSþ˜"ÁÎz~5˜¥œ¡š7ŸQó»¤f¿ƒÔ(ï’&ÊåD÷’x–fF £Ô®rŽ…Àöƒ F»• F%Z #€	¥d £o3€Ùf03F £[f £Û š= ó¦ °è
+ u	`^Ý`6Ž Fo 0çF ³•/ Ì×%€	[& Ã%2€ñ$9uåÀ| ± 0r°D‰˜vÊ m`Î Ý`òô`Î ›= z0SòWS—üå]æ¯ ])ñ—Ü$ó—³y]ð—ô£Ì_Ñü% ü¥õ~Yãöñ+ô’ê8{u,MãÉ³–2ÑË,ˆÞ¤ú‹ÉÓV¿GãªTû÷¹íQÖNµç“)NQ§×Ýjµ\_ÌÚÈËÀ‘§ç¡—†ž¯’~#çŒlñæ²[«Û~¹Ûuë'ê¤ï¶Ý¼_\ªåVÍÕû®:Å[ÃÕ Úç“·ÓÛM®n—»ËqÅÍõu×/æÛNÌ§é¡z¹£-fµ¿OÚŸ&Óùêvþi;¤æÛñ¨'jÝ}èz>…—òÿN‡ÿmz2•Ø‡ª½ì†•o§£»íL#ÞÓÍ¿3ÁENMé”³³¾û°œï–›uö¦¸Hr*;?CIBé³÷éÿw+/ñúxp_ÜÆH,ìð|³ž95}‡JÛaXl®Î–ëNáëÏ¾#µçH~ÚÜôjs»ÎQ8ëçëóCy©wâ¨BBhNr+Önøös0­*×T•¯ðc`?ƒ`Ô”öØ0¾÷:­Å§w²FC\žÑç/8;w[Cj…BlˆñP%í“…-<ðÛÙåÙ99b-7hPUòo›âyvqU¹ÖC©ý½µìœ¥óÒ§£gŽ[ä÷æfqùçõû¶û¸;>_îÔ«.$Þ.€Á¾T?ò%>¬£&±3£PA]MÆ„’À[Gõ=þ«‰6ÓNvi3 "Œ¦ô£ÍŽ6}ß-vR=Ÿ÷…ˆBC1+ÈBòåô{|1! £øòr½½AÐþƒKNC@ƒ
+M<$©OfßMÞ¨5/À	¿ju±-OzúâªBvg¹ú²(›ÊÑÜ’o¦¾ëjÚG‚dóã¯¦¿þjÔ‘’rµ×Çßx'LèP@€¯LZâ
+0ÑáýF<ZšÆòÃÃj$¬Ç¯Ž>þ` åùê^
+endstreamendobj159 0 obj<</BBox[454.6 327.804 652.073 322.804]/Group 164 0 R/Length 69/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ExtGState<</GS0 157 0 R>>>>/Subtype/Form>>stream
+0 TL
+q
+0.929 0.11 0.141 rg
+/GS0 gs
+652.073 322.804 -197.473 5 re
+f
+Q
+
+endstreamendobj160 0 obj<</BBox[454.6 218.242 662.029 213.242]/Group 163 0 R/Length 69/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ExtGState<</GS0 157 0 R>>>>/Subtype/Form>>stream
+0 TL
+q
+0.929 0.11 0.141 rg
+/GS0 gs
+662.029 213.242 -207.429 5 re
+f
+Q
+
+endstreamendobj161 0 obj<</BBox[454.6 110.092 534.6 105.092]/Group 162 0 R/Length 64/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ExtGState<</GS0 157 0 R>>>>/Subtype/Form>>stream
+0 TL
+q
+0.929 0.11 0.141 rg
+/GS0 gs
+534.601 105.092 -80 5 re
+f
+Q
+
+endstreamendobj162 0 obj<</I false/K false/S/Transparency/Type/Group>>endobj163 0 obj<</I false/K false/S/Transparency/Type/Group>>endobj164 0 obj<</I false/K false/S/Transparency/Type/Group>>endobj165 0 obj<</Ascent 1079/CapHeight 667/CharSet(/space/zero/one/two/three/four/five/six/seven/eight/nine/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z)/Descent -340/Flags 32/FontBBox[-365 -340 1153 1079]/FontFamily(Proxima Nova Medium)/FontFile3 166 0 R/FontName/FCPYER+ProximaNova-Medium/FontStretch/Normal/FontWeight 500/ItalicAngle 0/StemV 92/Type/FontDescriptor/XHeight 483>>endobj166 0 obj<</Filter/FlateDecode/Length 3790/Subtype/Type1C>>stream
+H‰lUyTSgÏ#y/¬%óbMà½).D§€»d+DPqÔ°	
+¢`Aç­­3G‡ž9­GÛ£¥¶RpÇ­ˆ;0*V@ŒPd4ô0'Ôû˜OçÔ™vÎœï//ï.¿{¿{%‘9I(ŠRÅF§.‹I›šZZ²¹°Ø\Rn˜ž”—[ø~±ãm€¨¦Ä	2Ñ×³Shñ•mÿ×]¦zB„Dy7úzS>'ŠŠZ]²aKiáš‚Mšoç¬Ò$J×iÒ‹KÖ—•¬Ÿ¦	1cf°fAQ‘fÌ¨LSšW–WZž—¬‹M×oÙ§‰ÐäæåK$9o‰ÿDÉÂ‰‰d>)™,ÑJÊ%û%?P±ÔªÙ)Ü)ÍÉ(’n–>”id«e;dßÈ~¢µtOï¡ÑÏ7fsPî*×ËÏÈ[çPçrçÓÎO\œ\ò].¹¼vMtýÚµ×-Ùm‡[½Ûk÷`÷yîŸ»?ôPzlôhöÙv'{ðÔyæ{žñ4Î9:zè(ÕyÎ—v†p02úwa £˜{}Ï’³ØÆžÙf?3S—† }Hz	ú8Œ4b$A’â "çÁ"LÂ¤y¸#y1B‰ÊlôAWtÍP‚òxƒ+¸žCoTò,U—‹›+`UIV)$)­£º0†8/nJ	Ð4ûE¥IÜi¦Ä™CÒ«Jq­	ï2°&‘0. TÁD¤¿G÷àù±z¾)n8×RÛ­¾w¯pŽ?ÊµøÔìömf(1Ã*³d±*,‡¹”ó}ËÁYS-= {¡»šø© °µþµ»Á¢YÐ}ôÕÌ^™ºŒ¿–D_i¸QÓ¦î¾»fQl|qÔÆ‚Ê?fÈ?®:QY£VX›‹ÄèWéæÇÖ5öÕån‚žg•>`µ*ƒUi…ðç&øú1XkŸCGB›\aÃeØƒëåì—Ýþ~6QO¬pÀ&m±p	W9À¨aÒHø_àc”%¤oX·N€Bxd²GÙä›èúß¸­î»µtÖÂ÷ÒÂç¤½¾J`«I´}}I(²Á-¡¨—ÃÅp&¤ƒÖbwðì@÷ÈèŒ•ëù?ï®Üý™
+¼ZH+=ZÏ”æÖñFúÒêäcï¨1]‡¡˜"ˆAèÃ¥fÅLE*ÛÒõíDóÉ¿©»[¡›IÈ3š¨#b<”àÄÀAñGú½ ^ÈÙ}cRñ¹l±Á×6Òwóe˜Ë¡Ð	 †‰@·‚stKäa^ñØxèû+}*ð@ÏkH£3zd ÇÌûËŒ›x…9rctr¸JñXT@;÷îôÙ;øìÝÓ·«îÜ>Õõ¨9?‘ØìÅ&.!6gî¬¸³÷º^ÔÕÂŸýÓËÂ9*¶ú3DôÃ>3u~ÈÑîVî÷ç[Šžª!Í¡‰óa&êQü[tCÿ¡…àÞÓqýâ1a“]— ‹¿‰Ïùæt!p”[R˜\¬ž_onú®íG ÎOŸû©À>#œófxÙO8ÿd4€ ½ìèÕÑèMî×:š<_ž†…#ÄdÔø’Æ¯öN¥	rMiòé´BãpÈ°âE§:ðl{ô¢ç½Žw÷
+
+±eß›OUƒ±ÑÇVÆŠ'9È„ùýS«õú|Cœ€ØÀA.dÉ‰ûé,}‚!'F`G{ˆ†¥â[Û8˜Ðs§ëšð»‹tzA|öl5ª^ALy	„ÏìôBïEº+3òNPcNCÐ ä†4%™Ãm&ªÓ*zK	Ä’,=òà¹~ÈXíFNÜ¼BúB?T‡¢ì®7u’Ä]Ô›ÐF˜p€”b3Ùõ»™t²á¿6Vhøõ{Ðl5C²	>rÔ$Î°Ž/ \Ð‘üé@?¿Ü~—‡]x?Ö¢»¼x]âšjÈ/SèºŸ»ô´Ðs™~”q½‰ÈQG0æ’òüIîF3ÔV8*¤­Rñ¬ciÉÄÒP«}­#äˆ4Ãbwuù¨®âg€Ä€a§.÷“ýuÓ*­já2/5•·©Ák ÞDƒÖ¾Z>'+s®>ÿÛã%<{ò?Þb‰¼¼#ð-< ‘ü>ŽOix:–«D~§f“HË?çµ&¼)I>¨$cW~Dnêz«ââ¨¯
+0˜a/Ã±ŒÆ …!R¬‘C‘½†®g H¬¡YÞ Æj$%Øw2ø“¸“žL|Ä=$AÚÝˆùÃã=^~¨…,rü@Ëa9’³È!ÿãr^lUb Ž0=	BÀ	Aû   &='*ÐòìW¤½U&Øê .±[ñø> )Hç Ÿ€uŒ¨F³tE4³a+Ìf:W%ÿÒh6Áô¿Þ`lmúâÈ¾%îASê=úVKmï 
+Í¸‡û¿Àâ7§®Âþ“j¢ÿ°.»AÍžÿ%Ô‹dvV*Á™Áyð%Ý»·ç.¸«À3ü	*x¬sPUÞÌ‚:ó¨¯:P>þ±¼>õCÒÚ.ñVÿjpSC\ÇàERG„ˆêèƒÍª›§;;ÚÊ–4ò·;éæÔ¨ÚÉD¹Sf‘Žú‚WÑ«¡÷}cEŒ*+O’àèWVòì®ñíÛÉws»Ò*!Ûd¯
+ƒÂ z\“6@›´ös1€¤@Š…LC/Úµrd’¢º$>†µröY%Pa…Œm²pHé¨nl“1Œâ®µßÀBñ†ã‰…öJx¥cÖU£vÅñ‰òic™Ã˜·ÿ›ñªŠâºâÁÝ7“
+LÂNwÇ9gÆ$.Z>Jvcb‚bi›Ã‡¡
+› "kb²Ë	˜%$ÆX‰¥Ä‰Ñƒ‚$¸+›b6
+X$4`*,ôœXE~œûðm?Þ.xŽÍ_ýïÎÌ{÷Ýû{¿ß½w,D‹-(‚!AÔ©I?@"­‡tˆ+7¾DÇŠEµ×jÀ!pÞ‡›ˆø3$ž'[à¸Ç†Cd”>ÝF@íP‹¸î¥­pš¦š²ÉÂÀ	H›U¹LRá2",Uî@ÄU.Õ®V\ªhÕàÒI·÷ñ!4á.zî³ä¾ûâÒÍ}ûŒp¸”7U_OYæ‹1£‘aŒÖb}ë“‘1û·'‹¶-èâÅ¶j‡0h7$HÙ‹Y‰Õ±BÄú4²BâíOL&;ûg[šÅ¥!gá!ö¶îîV[ÿ7m…†:‰;fvî4âgœeRÉ`á‹‡42ÃÛÙ´Æîì~äÛ´/…ëçˆ*~Û¾”=TèXÙ}N»X[Ãêä®è  Ä—uIIçm$n“Ù	óNŸ—¢>Tí<½ç )Gs[ƒ˜à@»ßÌ4½&„¾:2?ß;|Ûn+ÌøRú½µíMj~Z AkÉ#Dû¿aµ¸ÀêI}½F^×‘
+æJæ¶ú-QéÖ‘pš#ÑË¡ ú¶ÇÚÞ(*3’s“]âðü½®aÙÑ™“Y+qÅæî‡5#4*hŸ\
+,ôŸZX3:PÛÖ.îºŠ²‰¦T!8a`â	«Î0°NˆhÉA´ÿ¯áCxE½pqcÜÇigþPÞ::+pÄB¿nüFhésÉüŒK#ãuwÇ~dazêê/üìð•t–¨þñ3•Æüßä
+Ï¾ºõ))gã&'Ë}LRG`¥¦æ9ÎÇÕI=WßÀüí!ñã8SÇò³?e=YÇ$@F[„^‡€þî†ö&)žÕF¢b^;Õº[„ÈPg$e'S®ÏÏu]—;KT/ÃéCo¹DVà')‘\ÌBÊ•5/ÅfdæˆP®ûW¸wÙÆs—/t	×~w`#ÞŒØdºgRõÀ£Z™¿â^µå\­Å²ÿ\Nnþþœœº‚ó?ó†»W-c“Žv£Ô›xîÿØÑ¡Ö¹O1[sßÊ(y·ìX©X…ŸüüÈánÇÕ9‰Kòžéžpxµ†dÁç´?ç!‚rAø%oÄ«ØáÄ-i.ò²„ƒ#ÞŒÍ^Z¿!CºÌ/®¥I/0³ivýOâ^=O¼RœÞ-¼·cŸ‰i@ç6É,?NAh¨ikhzk²%ò'æØ†³íìÂÕZú‚+zÈs‰L{šËifa{§6*Îƒ%iÙÕÍ‡ðÜOñüè4 Ã¥ Bf€¡#‹ôc`H	#‘Èja Xr*C’'¦§:'îÌv¼ðtøö‚%ÊšFˆòxY:ßââgá9¯†
+v»­ëÍ>T·îPÁêõ·‰*vkvÚ^Ê¡AŠ%Fx³:()š*ÕÚ|@\°…
+Ø½ö{®—	‰Q×¸pÆ¶¶Zc©òô¡t×ß
+U_÷—6‰T°pC¹g™xÃ÷æ©ô–‰GÞ£hO–x¢å›¼µen±Õ½.	•¿ýÕ‘ãÒ·-+-Kâ›Ft,·Ú<ÿöùú/°ç¯Šú>õû¨øþ?ƒbíÙ§¥„ª”ª–U¶æšÞÞÎ‚_~!~Õ‡l	õÏdeLÌæ§î¼=Q(];è(J[•aÈ{%6ÎÚ˜MìÎPìoùÈ²v™Õm_œ8uZzk ½WZXjr‹j/HPO¥:HJ¾a_´¥ß¹"o)2=¸íBÏm{¸Î_"ó¬!?5'QØ²»Æ)Á·:âbµ—Sþ6ÒÛüU“ÈEýûóÞeø}Ú¹vjfHÃ&ìiE!îÇH~…P¦F6ÌˆYPÒ2òÉb.ŸŠÍšBéâ0†?AV¸•Ä+Q$Cü©¹‚šaô³Û„f~/øbq¼Šñùç)p€f!±P/‚iò8‰&MMØLÌ$†”¡:èÀÏIR)ÆÅõËQ^#¨F ¾épUÝGŸ	×Ë:êÎß€R<Ì<3¤¹‹óâ¡øí’lÏ7¿s¬¼Dâ‚ŽŽÂØ˜û*ìì;J>e ¦Ðwnv”³¤œL"îÝØTé¨üÇ§ <ÉãÉªJV¬~îÙªªÿøýà¨Ÿ¯uå´¯µé×~~ÓÇýüáàñú¿ C Õñ
+endstreamendobj167 0 obj[169 0 R]endobj168 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj169 0 obj<</BaseFont/NPXXFS+ProximaNova-Bold/CIDSystemInfo 170 0 R/DW 1000/FontDescriptor 171 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj170 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj171 0 obj<</Ascent 1079/CIDSet 172 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 173 0 R/FontName/NPXXFS+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj172 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj173 0 obj<</Filter/FlateDecode/Length 1408/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»"ƒ3[ŠŠY$B|4
+b­Rå¡¨ ‚,°å±+à.øZcÕšþE| Õ*/]-–RªÖ€Ö4¶Äú€R‰U‘†Fë¼kÚÙšôO¿÷»7çžsÏÍ%	•A’¤oÜÊääÅ	Á+-%æüô8‹-}ÆBK^¦'&²™F”'“²V%‹[çVù«^÷Òþ*—& V{Ã^Ø¡™âO×i	š$Õì’ÄÌèLK†ii¦© Ø\\c±–š³sŠ)A›R¦V¤æÌù–‚"KAˆ!<,,"Ô—gø·¨ÈPh*2ÚL™¡ÆÅ	‰¥V“a–!Ó”õ?~Ê£ˆ	Gh	=±”XF¬&ÖiÄFÂDä¹„•ØL6UEžZ-¡UôSˆ ¢ˆ('î“ÉP2•<@¾öJôjñzN‘ÔBê$õH¨*PÈ™Y;VSKÞªƒ¦zJŽ˜©ëÇoú¸S«Ã¦±hR³xœýÓœ¼8²¡¦P0¨Ã¨_1 ~¢!
+¢" 
+ã1!£0J”ƒõèœ=Þà}ñÙð³‹!è-²†*Û˜ÑNÂø€‚ý˜'0˜…Ù"ÁhÚ]Â°ËÀGž¯t“!’Ûôàƒu,îé öƒIHßÇ€Ð sÔ2ñÁúJëµÚ>á»®‚Usæ-Æ³˜*¡ŠaïUÙ@¨®ÌÎÁsàïÊ[õ ‚O„„ÉžtGÐ¨‚;(2P©ÂX5ÿb¡Žfqÿ[’· €‚LÇ€7F†ÍõLÁ¥p¯SþwéRÚ{Jo0yä'—äDpÇ3Ë2Ò—§škÎlY˜[¡8ÉƒÄí[Ê[å=3Ò©æ¸Ü}WÈG<”¿1ÒìÇ`ôÏ80ô‚«-$Ïo—‹õp“ijz-XP´f¥ØI_jj?õÐÛœ»NŠe.çÆŸþH˜–´Äw ñxÍÝž«5—D¾x-ÃwÀ;*‹mÓŽamÆÙÖ¶¦/]M_í°TIìmÐSG¡hˆ²+ý&ÂvÐ*ýN{Ôjñs¦Ã”t&^@ï°`÷ GünöZ×Ù+—D~{œ9L•»eCñF!fíÕþ×Õ;_·çVKìÇ(¨_z@q"L‚]àÍ¿¬‡}:4Óúúª[;Ä„‡t~ÞêÒÿ|ÎºÎŸJ€çÔ>ù—8-i4HpBtõq©%Ü­n?ÜxýžÀVÙd»ý±sAJÊ˜F_:uÍÍÍæÆôŒszús“Ä?éuwêd;òn;Ã¾µ´x
+â="y¥7(nt*Ðœ’€õ
+V«|LO™§Éß¿ÿáJSVžÈßíñ  Ïð­ðs¾êò9—ðí…âX	[6Ã17Ÿ“NeÉgKUõèR:Xðë»5¤ªgWJIå¦òZ¿sµ'Ú®wæ]¿Ñ—R–›# ¿hÑ\d^Ùû·IÝ»šf¿üÍ%‰Ç44äˆ,Æ*m²(î‘bŽ¶8t]'NI¼Ó:LïÙSº§D°l«©• `¨éà«8ç;©ûxˆá­í©C"{ã_£eÎþŸÂE¡g(Š¼ÏX¶dZ×	I9Õ?HÐ†<33\«þºwí¢SY¡’8†Ý‡É@GÚÆfÙ¹½r5omÃU:ÞùYeýþãBÿÞ/.>»|Ý'«‘Ã!ä`ˆF5$»w–fÐ›[v"8¶<´KRÉ.ˆ$¯@$uåG]š3«¥ÅéliÉr¦¥ee¥‰¬ç“%ÍÔ.º•ÛyL¶í>ú²T•j´UVeÄªÈˆŠŠ¿5ï–iÆ;Ç~¼³ûÐ	ôš÷à°V>®ûG€ ‚{¸A
+endstreamendobj174 0 obj<</AIS false/BM/Normal/CA 0.800003/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 0.800003/op false>>endobj175 0 obj<</Filter/FlateDecode/Length 4321>>stream
+H‰lWIŽ$¹¼ç+âÃ}¹jè$‚z@AË¡ZÀHÿd‹3ª{fÐ@WxƒôÍÌ?ýåçë§?ÿœ®?üñçë•î×…ÿ{½òõß½~úÓßÒõ¯ÿ½Êj×¾Þeö«ï~—uý÷¯¾~y¥käJ{õ}/,	¯ÿ~ýæ9°aïÓþòÊWÂ¿|t·ZÇÕ{½knåúøöâ›o¯rUñôùªwšùz§;Õ}Õ»•B#ïcôN£y}`áƒæœëjwÆs¾+–û¹À…e¶°k­W|Rï®½6…±rÖvmàÜv§Å…¹meÎ«Üë<~ÀÝxü|ý›Æ¾ÓÞ ¾°ù‰SSkÇl÷®ØbÝ;!—÷dëîðëã5àK¡™Ë¼&â¬×{ÞaL6‘\øŒu¡eZ®{.lØïŽßp†ŸØýãµïÊü!,”fc…r±êcd-“‘ïÒø¦:çUß$ìŠ,—¥sñ«ÒÀ©¥¡GîÁÅÄ|üñš(ÙDÎ*ØŠÏ‹‘„^jVa.Vf½\LÊ‚ÛöÌÏ¯7Ûì¼ú<æ;wüÉ|?ÏÿF/þõ»Þš8n5ôVE†‘î§µÞ%ß©75×»Ô|Ø¹ ÌÅô‡•á6ƒ>vüùüú¡º”Þ¦ *T(ö·ÅñÓç¿#Ç¶¼u|†÷üxÙôÿŸaÙ1ïônÆxÅŸoÏ(#áûùõ¶žoÇfå4ù®¬Ò¿ïù•Ÿ·lÚUç1‘Î±ÏFaø˜—Í8ëó˜“­â=
+ÚðöþaÐŸ?Ð]û?<ñi§_Eû¡z€1±È€F~ÊÝR»ìqÐÓiˆ¼~žíêM-ýÛPØâ}Mu=»:³®	Èk0F—¿æF ¦(øÊ¢ÝmO« Sù@–Z!k¤¦üñOgÁ˜è½”Ž½ÃD{|Ž×Mh¨‹`TD‰Cf%7¤ôx¸îÆæ(ÞNÖ	«øÁ«_Û`¡žØY\ìüÆ&¤‹íâàzE¥)ŠH£‘”VÞÊ¡:ï>DÍÅ”U*3šèð ~·»Š§võ‡0²®••€}yÿ ?ƒ.Yt¶ƒ&¡Ãh-‡…`n‘ëÁ­S@‘Ñöø:(íLWÔì„å/°6ì	ÕI5w^í7¦7|L» fŠÄ¨?2S&#5ÄÛ[¿kCý¿oÄ6™›Â^A»mµeÏ§Øu›‘Ô„‘7€ 0S9	½ÎFYÝ–ñ ÏÛ­Ðº:r´¿š¾tš“sÀ­×ïÝ8öRqùò •UÙÚÕ¦6Ü³½V¯ëSˆh|5!rþ2ÊX^7Z'dw9¢¾d+ùãLœÑ1UE‡Ëð#;áöÊt/dTÄfÍ(wçì5T­IsVu¡ßÐ'jiv-˜Y).±ÍÊ¨OY+àp`¤«ôÜÎî»Ó€‡Æòl‹´@Dãž»¸<MS’fTF^§ÔÝi*:­rÒ{‰±¬et’•7šÔ3Ÿe4…‚ìkW ì&Óò£3æ^£h4i¡MÝRiÞUqå8;RóFÍ:C“RÙº]ÌÂIÿŠÅe”dŠR¢èÜ™ÒOì˜†ä^nêä²{µÊ>“¸›ðaÐ=³÷Û¬LaX›kCV}ÓCØ<F¬½‰†ìj6wIå1ÙjËE>|ø|2K÷tÐ†`ÏÖ­CM
+ž/+Ø…Î¨y9oƒQ\î>%0SŠVÒnÍß*0w»=€P7õÜMD[òK4*Y|ÐwË§?Ñ5°â·LäÂ/²3ÞbJ$U`3qÁûf sôîSÁ`M»eÎ¿NÉd8ÌTÎ»H-	€OÚ"§*<*“Ä*5Riòº6Š¢„Ï.UœÛ¹—†åþâgNqžÑ›6”S¤YªÜÔ< Æïs÷„Èe"Áp¨ÿ("VZ¦æ2ªðêëÂ¾~›®ìöšVÅØÝ}š}!fc‰Z[¶·•^³ýÖ†ôé™W5Eÿ<Be·å«:h•ƒ|üd?J&2|ü/;:|hÍc8Ó÷4eˆ)š02·“YýµZÏ\yzC1kZ?äUøLÆ¨}Ž£0›AÖà×°eÐÓ´àU„®ÊÔü}ø­oƒO½ÔJàªZü6jVA±¶m^èž£Û×ª²CÒN<ŒANoŸ·3ã	‰ÿéR"k•#+HšýÐŸôÐ¤VÚ$Ýi –3þ¡;
+Á0GuT»S´Qç TfnjØG5Ùdê›tY#±šl›r´Ô·0I-K¶0‘ªµ4Çƒ1	’@ªkÇÊr,=Ð€b_â¨¤7Kºÿ-M Ëij¨mUŒ;îWÆö”)•Çî—GÞDš ˜!¹´Î}joC-?@¢v+Æç:3<B2°á)Lµç¹Öò¬ÊºËÙ"ÏË	(ÊÿÚÔ—ŽFŸ
+*ß±~Œê;*&^ˆ^øbL[ßµuý ñøªCæñ.Ô,I¬¢ÏÝ#!È0Ž7ko=6ï¡«Œ†$4?kFˆÇm …ûÈÎj1õB[Òm„ŽÒÊ°E	þîýÜ_jm'zkˆ\MCå¹dxlÂj½µ+OÓêÏ´§¬ŒôœkGj»ÄÈq•d-ñ44K„«‰o‘–ÖžIK*9ÇÂþ5”­[B_ÄEèÈk#Õâ˜ìSÔkvŒ0b¼ysŠ¥2¿4½XÍ
+’(.ÇàB‘e4á©{Î1Š¯KDjÈß}ó\ù‚m> &]ý€ðßŒÅ…Œl¤†Âå;ú.åÉM46Ê#ŠÜ^2ä¦uPµÂÓ´ŽpÝnÏý‡]”]uz*&š-T¢&Þ¢®£ðQÍuÎ4'îb5 µZŸ™C9¢hž[ÐÃÆMÈ hQ«<‡ãm²¿?iîäšT64ñgt‡ñÀÕfÈsEù´Ï¼âÀÃÍn_·„þ]À„€&²¥òŽ(§µO
+&Øe‡Þ@~|sˆÔ‰"­z~ôšßðB™/+þ˜X–…‚g¾¹ØšÅ.ž€ìÊVøff‰íÇoæª!ñÙPžm´I{€o#³¦O°èF³ˆ!&ÛFÝ=6CoMÂP­®Eò.‡ý«GìÎq0ªQ¶G0ÏÚÏøð-ÈU!×QÅhÐK;—sÁÏ^õ4³w0Pž,ª/}®Ñ¿Úîˆ–û¤ñ´˜bí¼ØaI¶ëG ™Äa˜å“Ù¦BVA‹zx|á¨øa¨„¤5]þ‹ì¹åÇa:áÝ (WZ7îŒŠ÷í³9ê‡xˆ“Ä"ýÌ©„ž<³Ã×=XBûeèËŒÛ„Co™ ‹oªúþUoÂ¢ÏÀ¢V&Ff-v’Ð|rtêCoè&9¼¡YŽ»K:Êœ#…×=cfÃ¦]Ã»UWI<ºàéT‰O@¶ÀKRƒÛ‰ðpc:xµZqÒpƒëâ:¢È>3Œ«ZvÕ3ü]ÿg4{ªÄ-×–ÎÃ÷WÙÑ;øFxìóù	ÎÏ {‘«Œ˜]ÂlQk„’p\ŒEw@àS$oåÇk–ŒUÜ£òœ4·£Ì!ó,±4¼Í¸¼Z9v«l!¦7½’'E¡“Õ÷´pÃ±G0¦Í¥Ž»ÙRãÞˆ¥û,©‡AANêK7Û¢ƒIðˆöóeYö>(%db!·æCltx›çRF÷ÒË¥·m#ˆãw}
+¥ƒÝå>¢@í:Š¸H[9E DŒÍF–\INƒ~úÎ‹Ë•D[.rHä!–»ÎÎã7Tç”Aƒèº¦…”Ï<¯àh˜ëÞyè+º^Z2ÁÛ>¢ØÀ¸$HbS°6q˜_A.@¸e!®¢âY„©ÿŒÏÈôÃ§ð´@fª©}@QáYaF‚E"” 4ó¥†zSo/ÛÐ”ÐÛ}ù›ÆbÕÁP‡VccNó$_‰Ñ‡u^KB©}Tî”Â±âÍ&li™´$²ý‡Q2Dg¶‘tD*q>ú¹’Ñ.“Ùü\%}\Z6…¾ÃQ¸±½ìmÎÎåDX 0-|‰ä.×	H°`ú¾±EÖb åz˜ËùïS‘‘‡A…Œ“(7ÔëåonStï\"5dáþÂ•ë!6§¥‚žqCLä_ï™H¡B+Ã|Š¦$JÙElPkÞ‰¹ìÍ3ˆ]›ÁcÇéÈiÎ§Â–ëäCšty
+íçÔdÁˆ ©Ø•„j±+Ô”@8¬IÀþ$ˆ>3ó+%$ú–¸§Zþ»÷4[ì^Mó"mÃã,ž<NŸÉ;šU0°&•÷p”>;0,„qr BŸSØÊLLöÚN
+œ5MÜR¢w˜äp	®Éû.'R¥l¤±ôÊ°tü Ç?`r¤B¥˜ÄˆÃŒÌ±u_˜8ºl,Ô›D¢Ð'€D3)p¤â(Ê{6¹ú)á†ˆC·BA­1ÆGa*0eŸSñÂ”ÿ6˜òÏ©0ÂRûýî›
+º;QÐYÍ>ƒÕêGXCOÊ"—>©Ÿ%ƒ™Á0ºUó"ÈE0Ü­D0ÌÒÁœ+Œ9%#>Ífí€`(®@0üÊŒ`øõ‚E·‡`Á–|`±.ÌÕ¶@0Ã(ÌûÁ¬ò‚…ºD0¦KA°£ir`0lÌƒ•
+‹©`0®åÌ`È‰æÃA·d°dó¶`°äã·ó¦`°äö,êÁL‰`®.,¸Œ`±v‚ñ—dCMÁ‚.Œ[RF°dc`Cf.ÌòTyH`H0ƒ…mg?™¹uü:¹h0„Ð¡ªÍÍäÅ¥zuOUÍ§‰… Â^ªf1ùNŒ(åRAÁ?öØŒZ)›À~	6˜ž-ká7x^£!š..ñ÷ûæ¯¡Âš@ŠŽ‚ØÜÁY¼Ná{¸ö,DZC´ØÊ=xš¤+v …¨Ä«re€Ü+I›åóè×ãWÍäE³~øxûÇýû¦ýº»Zt»êú{ÍD"¨ü?z®Ñè9t¨¤Ó St2¨Eu¬Ñ‰NœþôÐ-Úe·j·Õ§õþ­vÕ?mws»ÛVóÕ¢šÁéŠútÕü8™n»aåzU-ÚíçÝú~¿tÛí9­;º@¡Y†Q$~z0P¨!µAÆ»)ðvfU5m?T/AÅvögóó„ß’­o•ÂOívPH—ˆY	)‚Ÿôª/ºÕM¥QÓ¨'¼Ô ’ß¢áÍf=ƒ¡kúµ»›W¿¬¿Ì«‹õr‹îù1)*¿‰…˜Rˆbž¢DˆyZÈïí]÷Å˜GÅdg1õ˜{Z¿ôi1êPL-›²gtáFÄ¸Óbø½ÇÅ\·‹îáŽ:”bÅ/–ýb¿ŒI©Ÿá—ðô%½Æ´“PÉyÖ¢=oä_ÍàÒ¦óÍüf3¿¿åwFüpâR~›Õ˜<7Ëù+½q”—#’té“×Ýê3'¾dßˆ}â^žÐÕìoØÛkèd±Š.c?sÓNÞV«cÍ[E:ª$¨œ™'P5©ñ+½3+–/eé9ÐSÒƒÉ³aox~I,ÀRÄ‚~G»ðîŽæPüYbË…eð§í_±¸€P…djåH^¦d†Í-sW”·ár,ž‡ã#¿ÖÁËÁš´w9O­>7Tââ…š3ÖûwÓ‹‡ÝÊý+j	ðû±7yu}YMþ` V.	B
+endstreamendobj176 0 obj<</Ascent 1079/CapHeight 667/CharSet(/space/zero/one/two/three/four/five/six/seven/eight/nine/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z)/Descent -304/Flags 32/FontBBox[-351 -304 1111 1079]/FontFamily(Proxima Nova Light)/FontFile3 177 0 R/FontName/FCPYER+ProximaNova-Light/FontStretch/Normal/FontWeight 300/ItalicAngle 0/StemV 52/Type/FontDescriptor/XHeight 483>>endobj177 0 obj<</Filter/FlateDecode/Length 3790/Subtype/Type1C>>stream
+H‰l•	PgÇ§g¦{8aìÙ0£Ý#ˆ Ã%"XÈ%‚\‹ƒW9•( èBÜ*cvSI6K6«•àVS!nâŠŠx€
+­q†QQäB`Vãƒ_OÞXµßÀ&[»µÕUýUuï{¿wý?J¦”Ë(ŠòŽ[•º>6Ý?µ¬ôõ¢âœµ¥å9“Š¶lÝíøé#é(I£”f¸q8Ž¦ŸžüÔJƒŸ„OƒÏæÓÐK&§¨ÈøU¥;ö”9ŒôÙóó²ýôÉ9eÛôEÅ¥%»JKô!AA‹õ+·o×OnÚ¥/+ØUPV^hˆËøõžú}~A¡LF‘Gæé,óñ–E{Ëd²Q6Gæ++—UÉú¨j'%Êò$y‡b±¢XqS9C™­|SY­|IÏ¥#è|z?}„þ†Q2YL•ÊY•®:­ju’;-p*qúÊéŽÓ„³Ñù¤ó—x—/\z]ã]ßp­uwóquûÀí†»§û÷ëî/Ø$ömVdyø{äzœôèz5¸Æv¸†²ƒ³ÇÖ`ÆmVg «˜{yÏÚ«X´°çö‰Ò H™-’Óu…†8iÃH€¸;!É‡		˜Œ¡¼£Á™1œµ‚`&ð³@ß€Èó,¬.·*(XjRÀRÉf02è‹†“…/€¡ÙO+E©C¤¤x³âšFJ<™ähÁW¯ òšßÂÈü5Ù|ÝºùTë)«®»?Ï9@Vàýí>jDøHô’ÂÌÌêÑãßs)g¾ÍJ>Öƒ< )í€ þÁT5taLôü›è´`å¦ôlþÔúëËWkzuC=#B"Bw”U¾ÿ{!Sõ~Õ—•GtêÑgýùþ¡‰™sÂë¯
+lYu9$Š’›‰‚qÏ¸Æ‰OE?)vƒ—íqt´«¤J»V©ØO	XŸDê;´™=ÿäV7ÞÙ
+xŒ‚7ózP—^¼í5>†ÑÎásÕù=tÃeñóëº'Éó‚bbý¥Õ^ß,°Ÿ‘Ózš¡ˆ”Æ?š§J#Ii|ÇŸ€vt^–¸±”ÿSUåÁ*-ø\˜Ó}vû¦ã|í9º)oÝÉ0&ÅàJ\.HôæVe†"ƒžÀéá[|Û™Î‹Ýº'F¤vMu¹„"uBZ­ Vs“36]o_m”h»²I¼ZÌÙfh7g›Ô#-Å!õ48˜þ´d£Q×Ãóê¾þêÞæ-¸ òêìY(ÏD—Þ¬þr^=¾;rm VÝ'qpDçâÜ·ø¼Ñ¥fTûmGãðýÎQd×Aà"—¬‰jƒéõg÷óõï —7WË~ö¦[IRDÊ4™‘G=Üúº+[ïë ©VÂrˆO„HL@Ÿ%³‘BŸïbÁíAßíÆ£Âvê×ãBôÎ=v~ÀÄ%ÄdGëV‰@u]</¡SÐ‡;@J!JÂ5êé¥Bº¥ieð+›Ž!ËKÝÊ´AÀ`œ”ÁA˜] ±‹a/UŠpH„JÑËj‚Ç–l‹zÂª¸vµƒ¢?µ'æ  –,5™þ¡Xu•<aL(rP	…ª¡†Œø¸ßd.°Û98¯©Ô£×ÄG³BöG’ýCCŽ!UHü>dß4v·jè´œèü%:4 ;¸Ã
+ˆ&oW0vç§.£;Ó£.¢L‡)è‡zÌÁ +¤,x‘9´ˆ”Õ$ÅZ„´ˆ<ÐÀ|H†5¨Ì°ˆ1Ù‘“,¤‚ØgèE¦>hzbŒÀ¾÷s¸äb.E‰v9ÁF*%¹hbØ]$‘íÿÙc‚öÿþsßáíf¸4)>%¦©Ï%¾	âÄHÃíöâ,ØaªÂÂØM!:&²¿|¯·0ã¢pþÝ±6êÊúeÊ%Î$Þ;Dh®pÄeVHÙfHÃf{4§¿4˜ C"ødJ®¦m†t†õß'ÚTDÀÍŠ;¸ô_—ué@ñð6‚T’f/Qg$%åÕÖóìç¿XK{5Ý¶Âœ†N:šÁ»vŠ–¨IO{U=4›LRŽÿö$M±WBâv“¹¹ë <`VØf:(1XnoÂ
+©‰'öÒ´Ð_0ð®4B³àMLºVV^“›Ô’Is Ûo1öpéFl2gÝ*^%­cLð—–©a:.€,0’É]@ÞF$+1Éw4òÒ=.MÊ†ásÁ–Â²1 '„£.ãÙý$³Dëu…û–ÉÒÖ@&êžÑpº€0’ÜâÔÔPž\&uÂ·¤.&¶—Û¼D¯I$uƒmú_ˆŸ!{Z«O7óê×;£ëNÅuÓêËÚá´Ø‡Üÿ¥ß½N˜²¼Âçzº$7ëw©:öïø¨õ“ÀÃd„J4ífÂ	úû¿µ»ØÐnTñøgG±Ž‚/©Å-NI™„¯wÀ[ðŸL%³Í£Eãc.¹Ùº	ä:H0=ºÔ¢ì˜ô·ˆÃýÚ®¶æ‘»wv¦]âÏœ£[Œ+OúêÐÝ/Žè’(‹'J„Çe#;jÓó—ãÌ€Ø‹M›yö½)Òp@c–JDûŒPBšÄmª'­fi¾Ya…8Œ™MoÅðsXÂK†4{ 
+u±KðüUÌ èx)0MÅT¶nvô§Q2õ8«édÀ!e«õi|×þßùáÕÕu…Ù.÷½àk†ÇÛ±>g«	´@1 F'‰)U üH”…%EdS!±A–…Ñº¦fL:M$¸2£ì¨(,e–·ü
+¬;A3­–mlÓ‚ÚÖx.s·ÓÞ·‹™´ÿô¿³ûî»ïœï|ß=ßÅwé†g_©Ã3ßPJZšá‹ð<=õ`;]šÍð'Hjà:IÃ×äh˜JÃlòƒ§!_	)xq
+)ÁŠï«±L?DÚàoð;¸ŠÒò+r‘ì‹Tpœ\#íä¯è
+ûaqò²[8O‹>¯‡n¬8
+meˆ‰ø‰	ü4k 
+q-¡ËMj·›ä@ƒcñ%4xÓ€cÙ@lÀ‹¸–ÞCuÐÖ1Î¨‘8+óûñJ·{Î¿)oÁ«ZÛnäv¸Ú&Ä+ãÆt)žu•ëÛ3Å´õú5?¸öëí_M·»>Óv‡—V˜¶‰›C—§å¡ÙñáÚÒN‰ŽB×¯ë°Þ›ÍQ~ü£ü~¿FføÁ«ì«^#=+¢o.R?“ry•z£-V|&À!ÖÙáë›!l2™Dˆ¼u$,3»ÇY-qéNv©<£jˆî6A°æúÀy·]»û*®,5Šm‡Gà‘é[€<ŽúâÒÅshÐX|>M$kI8ÑýwzžQð{(YÏRR!iaFŒ/_Ø*’ègbI­•$ÝŒ‡è+^»»Së/©Î©Ècrç "¼·\¾´kG‡Ä±ôƒ¾rúUž1ø§'”^ü½5 ›ìph÷v¢Ò]ùµy"a¶Ü¸XÂqÍH!‚º¾Uq‘-mµQ€ÃO>{D¢†ïú±±»Àˆ¦ŒÏrB|¿jQV/jdœµèŒw0S¶îkó{ï6i[{Ñ'õ¦co‹›Šô?‘J7•Ì²Ü1RÔ:NrYV¸ðgòCaÛ˜¼ß/Â£w='ñ~üV!Ë/<Ç~WòSÔ $Ý|Z©·w°Sz%êçKŸI/±ºËµp&¸£:{W&­ÿf°þ¹S¾`ý5mËpªh·ÏÈjüãŸTÎø-[ËÊ+µð±á_I2V±Ž³>»WœqÕ$J}Ëlþ»9jj6Kæï=À^¡Ýjmoo°šêêL¦Sm»&àdl6Ð9Tä\Zñ×Ÿ~V0ú˜œ×ßÚ±ïÀÑcí;;ÑáÖSïÿ^œèŸ“¸¼àW¡LÉUS43©+˜àMEQÝÄ†p™’+<ÉÞúâBÚ£K)ŸÎÁÛÁb-Af[<`‘yÿÒ´Þ{ÌB™{]ÆK%;÷j]–
+ÇfqKVÁ3åÐ—†€Yf)Þ´|Û¸}Hœî(ÏÈ¼ÿ€uœù¼[/ÛèË0†v>#Óé¤À8¯À8°#ß¿¼×ÕïAY¤tHðí¨º©ÿYK@ïºd'k‰î§
+õ‰nžJF'¹ÂIxö{à»áÀ\Š‹!a9q„‘(sÒê`³²—å¡tàG$G€VoŸ¬¼,‚pã.½Í$¥,!=×ø‹*J¤?RÀ(“ðãøy*6YQlŸ³ZsOPÌëHÄÿl¿LL|€nO1LRÈø;X•kO‰O-[â§@˜ž¸0b—HT€Ùå
+o}GÀŠJ@ò…î¥‘w”œùiÚ*¸Ïôµá?>ÞøÛ¤16So,Ø%ñ]_X.ÆâÀi•{Ž©í>¡p`¢öš+&|×þ‘øé†6)ódnËÈ*·³ë>¹æµ­­Ù+õç6ˆD•óò‹	su~³4ÝðECîªüâŠÛÏÙ÷Ð[ƒö Ö©š÷¨!Ï"ô|Úd=%™{å ù`­XµïŒ]‚9*^XYHVR™’6ë¬Ñ§åj‚Ç‘ùaÛë•¶+„çûálÙ9¿Ì·ì8ý~¹Í•§äÎŒÏîèÑrë'+‚oÇ»éðÚ­ùœ2lF¯(Ãëgäçx#ÚF9›Ðø¥¡'ÏÐáuréE:¼iÜ$Ó¥ùÊðŠ$’Õ8ídÈjFÓ0Ÿ>˜‘[^«q2âR‚ºQÄÛÔø	—!ùp„^³,(—¡Î¹˜Z‘bB&±|ryH…*Ä­'E®úº¥”PŽ]ãD'ð{SŒø®÷N´¿ß*ŽõÚ&OKpM³þ^ÎPØ÷Z**©7xC´Ôýð Ä=ÝèÄ¢S5
+KêQ,9‰“>,¡>òm	ØYbhwà674ÝÿÂ[©GlmnbµmëS››ÿÑù˜íÑáÇl-Œþ0r¼/	ÿ` ËÄÍ
+endstreamendobj178 0 obj<</Ascent 1079/CapHeight 667/CharSet(/space/zero/one/two/three/four/five/six/seven/eight/nine/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z)/Descent -368/Flags 32/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 179 0 R/FontName/FCPYER+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj179 0 obj<</Filter/FlateDecode/Length 3881/Subtype/Type1C>>stream
+H‰lU	T”×žaøÿ„fgŽÌèÿO˜A¡ ‹"°Ae•%ì!ÂhE@@Œ=§’sŒéQlãR«±4‡€bË\@e‘¤P!¸„·Ô%÷'wl{g0i›æ¼3çÍÿÞ}÷~ïÞï~O*qtH¥Ò)Ñ‘I™‹’}“ÊJÞYµ&/¡¤2oæÂ’¢¶=£¨—Š“Å©®«Æê8Õñè÷ø( D	óT­SUÜ%RihLdIé†²U–•†ï·s|ñye«)«Ö”——ûfÎñ7DìFå†²‚ò‚²Ê‚þÑ)©Jó+
+
+%)‰ÊYâé!Yè!‘HÂ	¢Ä$™!)“ì–Hc¥ïIb,ÏeY²½²9&9îr<ë8ÂD1åÌ¦‰¹ÏÊØH¶˜½ gååòóN&§(§NGœž:ÏtÎvÞìüÈ%Æe›ËI¡“ÖMºçjtÍpýÔõï®Ü’Ü¶»õss¹\‡ÂK±ZQ¯øBé®ŒUîU^œT7^S'í®‡Æ#²î <Æg,ô®Ñ¼¬ÁÆñ9‡C\C¸‹KÀ]zL°¼dÇàŽÃoc¤@òˆ€pŸá˜Œ)!Žá¼è«E…Å×Ï×ò  h{0Öà‡
+žÃˆƒ•ãë¥`£ÌZ0Ž ’ÅB´…€0·¯TâŠ&šÀ$kÖŠ[A…õ,Ä€ûýÇÀêÀ™Aôô÷^¾”šÉ47µÕýM±µxÙëaÑø)æ
+Üï«@	¯þ t§§€§zôÀ˜&ñô79 ÐCðÓ!?™Ý³SPÛ·§÷Â-È|¯c :Ï5'¤ñ×g3MÍm‡»ô×Ï—¾™™U±Ö\½­J@¥|Ûî¦êZ½zt´±,-Ã¼2téÂÚ
+¹ç`%ð ‚zp¯^ï)Þ <Ô‚'ðw@5GôÆ÷[ç0è½rõ¨8Ãëq±œ;dÃj†Iàœô:PJ·>ýµ&þÒ­pÒÃœ#ðè§"“V^´R€0èÎj¶ªäK™ÏO6}|Aßÿ×ü„T³yþ¢øÃÍæ•OÊ€Â^´]äóÜÖ`Òm„·Àïéc l†èºpñÛæ"~ëÕÛ·ë^tßý¶ýówV5ðß1Ù1µ¡zÌDhD#ºiròÓÌ´ôunæOi9|FßÕ^)p+VŠ'@%=$n‘›YØ&v1­[P#rî“*àÄeÀ¹zœuàe›Õ#Ç!BC6“Á@còPÅ^«åÕ}‡ÛOë¨òº³¨@%zd j^[V_¯	+‰‹Õ©D%´kÒ£*ò7óù;"kÎéš›?ëîj.Î!›ð”&+¥(fQZýé¶¯jOmçß.Y¦ã½K¹q¥a¦ÜÔåÆ(»Ö¦Ékî)ÒC&0`„\XhF?£7jÑ$àzãZcÓá7òé‰†¤‚ýG-<œ…4+Š²*2õ±Iõ_67¶ö5¼»]àžäDývPÞ_Bhë´Àâîñ £Yüðe C™:rÎ²êQô#4à€í®e¹›ÕàAô›nîÝÄ¢?PÊ¦€—úy·þÉ‚úÚà“[É_D}(¨ÅŽ=ç.ÞÒ,B5ok^O<¨¡sÑò–ºÕùË×eõ’«ŸC,{±Î’—½º(MàžÚúz©½¯§ËÄÉUð»54Ü" ×Î¤–$æEèÑiö(¸ƒû×£àÔwyyZ­ Üef8'dýô˜ŽhÀ<Ìš!]à@gëÝ9DäaR
+B»…JóJj.zQ÷HkžÖ2u“Ã´Þ@tAfN¸­Õ”µ "®µy!b(p˜ûÃ~Ú&ú±ÜFÊqýÿXRÐúŸZÁÔ ¦èÄMÜ^€aBÁ
+!§B:¸éïáa~‰D‡Ê×§•%èÑíÇ»»]¿T˜S/€K's3#øò¶»£-tçã(uþÞõö[÷ÄÂfÄ½Ø{Ñóe í…–ÃŽ	ü0Yy²œ­gHëiyG«&§¥cC¦=º³1=­Éò¥ùyq¹«j¯å¹sÿñ!æk!’ÅøöC7ƒôÿ]<K”z4O~î*Ã%Øêrâ‡¨â|ê«ãâ	[d8DÍ[‰ÄRÚ$6ÕMãº	ø9,†Xƒ1Df0Ûæ%WÈ!ÉZÁ\e!I¬`(û?b;ž-L³]ÊÅâU1ŠÁé¶“b*…Zò_|}ˆsö*äÂ49ÌÄY“$4SëÑŒ&ÌåÅ-*Ãèõ@Åü1ê]ÕÍû¶7ep&ªxî$%“½¶vÀï&8çI‹X0>'pžÿ½ìbE=þJ“’gIáÑ—Nø²O¦
+?ƒk¼„€ýÈ@ÛÎôI3ß÷x(ësáò‘¯îëðX¢ùxÙUo­[)¼1âÖ?‹ÙTYþÛ2=×þ3€ÅD-Ìeñ°“éý¸¯\t ù»ì5ÜDMí}¹%™G:ëÃ^ú‹%Eàö‘Ð‹ñ ”ž"ƒM$òîkâ:î-‡ÉzX|÷ÅñFÃQt8,,ØŸòÇ&ÝÉcµ]½™çù›Ï˜+KfyMA¾A(#¯†5 -6´ý:SWPPøË€…§sxnË+q§w‰^ìRb}¾	*ëg$ÜéTUÓ+îvSõ®„nø“ç!ËÁ<FrÊ‹&4YrÿŒX/cFç(/Ð$çžTƒ?zØØcÈRØ¡…hìÂªÿŒqÖÝ/î¶}qp·âqžÝzÛ÷ÞêRñ†–*É6ë`›µ“µÿÍxõEqžáew1ÁÕ¹åeã®ÐŒJ4!üHB"3Í¨‚‘òC‰P¸ÃbrV)A@‡ŒQ‚R<@‚èA8=äN	‚2ˆq2I(“Á“!“ê»öeÚ¾{´všþÓ?næ›ÛoßïyŸïyÞ÷]j`‘áP¤õ<mÈÁF­ÐÒN75…ÆçÔZü(˜Qx’F°¦ÁC,†s¸óñÈgñ×q‹ð;hÅ¬Ð÷¯É¥œTåšÆê98®Ê<E3¾fm'feV8þïJhUË«§ZN–äàŽÁçlŒwx¼3Î
+i¦o"¿„çÆ'~Ò5Ä(€žT´8P–\Æ'ÃÃ÷mŠ‘;ƒÙÖöÎêkÒ-kF¢òß–{f´Ú?YE´ã“›†ú{jÛšåÛ®Y†·ÞI“6§ÕÛ:Ú?r´üN–YŽš€]2-t#F]?Å? Ïˆúé$N´÷ñI­]9½SSþÓ¸ 6noâvJPäAœý@á|“ùJ]»ô¥=6$$qcdZRíyƒ"Sd-®K<Ã4A‘ýú‚ß7/ÙšäÐ!6#w§1UZ×3>þÉõ¡ËòwÕ*cC¬-#úÒ2	ýûâ²ŸÃ£HÏC< *žàAõÄK8ûö¸³±.ð_ŽZÊASÔ(z»ê¯´Êß¹fä¥än‘Ölîwô|~É–›Q£™¦pýæáŒ†Á‚9t+YKklvyã×ìîÌøý)ÒK‰Wû+€øÁäø¥Ï!‹‹e8+ôãM’)xˆë|¿åÆˆ$à	²…0ðê—Ið`&	¥êö=0~u\G]ÝÅS§ŠOÊõwÙŠÜ]Çß–Vüf½¯’ó
+2_ñB&ü¤Ù¢zf	°ÎD(ÑÑ.\¨¿9?&Ñ,èkƒõŠx_G^}·oÛtö	ÿ@ ´ƒaþk­J"¿bMö†	U—¶É`T}¦!yßVbÁ16æp|níÈÍ ›°êœ¼ºh×ž"£zk›æ¾Mèõ	‹Þ¾#S†R©Úˆ0ÌŸ«ik°KÝ¯)½j4NuX
+Is†Ì~Uomi±ZÓ[¶¦íLßºõBz»"Þ[?{U¢jD‘š\Âõ³ÿë­[Qz2k!—»ã°©ìèaùð/ÙâSUGj%p»þ<©‰N°Å	žQÝ=!ÃÍPEßY,ús¸3XšNçÐ/ä{©ßÍYUÛ¯É›äC À¬Ñà$]c!‚¼F?Ñþèyº;ø‘û!þJ@äºÔÔ,¹{Js”¹.yQGû	 D^´5U[/K×Îd¤(ØK¯ðõ´4ÚæþŠþë„ßRâ6õÑßÑ7}Âb4¢Å¡ÇmÙæ¶‡ôÉ…\"û÷ÿ1’”‚ÓPöâ451-7:—£.ByÝ PÖ5,uàOƒ—FFlk#ÂSÖ†)¤°åF¡c) /qbq½JøÍm]ûz$Xx÷9=hÕ.Œ‰ÏIÚA‚ëÓX$ÅÁßÔÕúÄØWÓ’Î6d2þy§ñ¿°Ç†þOüÇV«)¾x_s+ÅØÀ_y;®>†üºj%aÐÝ_Á‚ÞkuŽ6Kx¸çºÛ¼W“jÏøÖÚ±/“¤Š¹Dá<˜ÐxÞY£ÄçêS}47_¯µJ•%G>Pèž££Ó·¤+â¹ÛTž„Å¦ïaà¾‹…Zo(Œ¹_Ÿtu4k\ïÁÛàŽLMèi%îäö“ÞU7º÷fž“f[“Ö6¼$¡õ2òcJ÷A«)Ý{wNþ›Ñkš›wÒ'k	ÝÊJƒêŒî/”f6ä™ô]-•UÕŠhÉžf÷æKYµ
+ìÑ* xQµòÒÌŽå¼˜Ô™<!EÎò¦êŒ¥‘ï”†Ó0¢¿â³ò¶e'Jq;k>U Eœæ_p¼ñ`¤÷¢¥Y¢œ&pùƒZÃ@MXÄ«Fq¨Ã	ÔÁ‹Ï’Ä_/… \¤mÕ•>:AM²À$–j{½¨I®Âaf‘å|px•¶ò¢§³Fžå~„¯Yá•¹sJÕ2þN=ŽÃH(ƒ`0±4,.C¿¥à§­ MŽe,øpTCX!
+€6<zÑ¨#¢e B/fç#ÇŠ–÷N7Ÿ’ÆŽÞª»8	Fõ†×Ï`CÂì»ûÓØSÞ¡]’éwÇÊ*‚o)…­†Ú§¬µOÌã šÙ©Yod`{°‘ÞýP5VtWüõ$¸žæÐpº²‚—ÍÁA••ÿpŸWêþ´å)ð|ÚÒ]^åîž•îóá}uTÿO ×¨
+endstreamendobj180 0 obj[182 0 R]endobj181 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj182 0 obj<</BaseFont/BPSDMV+ProximaNova-Bold/CIDSystemInfo 183 0 R/DW 1000/FontDescriptor 184 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj183 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj184 0 obj<</Ascent 1079/CIDSet 185 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 186 0 R/FontName/BPSDMV+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj185 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj186 0 obj<</Filter/FlateDecode/Length 1407/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»"ƒ3[ŠˆY$B|4
+b­Rä%*ˆ ‹lAvyí‚¯5V­)ÑèQÄP-ò’ÕBK©ZZÓØëK%ÖÖ;x×´³5éŸ~ÿîwoÎ=çž›K*‚$IïEq	‹W&ÅZJÍ›3b-¶Œ™‹,yYî\¨,È¾åQžJÊZ•,jt.Kå«jz=@ûªz4~ì	{¼`»fš/Ý ñ'h’T³K³¢²,™¦eY¦übsqY´ÅZVhÞ”SlHÜ˜:Ã°2£0×`ÞlÉ/²äÂBCÃCQyy†‹Š…¦"S¡Í”b\’Xf5f²LÙÿã§<Š˜Dp„–ÐËˆåD2±ŽH'6&"‡È%¬DQHØTÝAºkµ„VÑKL#‰"¢‚¸KN&CÈ4r?ùÚ#Ñ£Ýã9ER‹¨ÔC•¿*_µ?gVýxm=y£Z)9|–n|_¼bàV½[Çk¡UÍâ1öOpò2àÈfð‡*˜F5Ã°#Å(H€øaˆ‚Hˆ‡HŒÇ„ŒÄHQÒ£ç¦ à MÏÀ<[ž>{ÚŒž"k¨¶í$¬‡(ÕqƒÙ¸é^x M»Jö~9xÉ”n²?øSr§¼°¥À=ùÔ>0é»èhŽ\.Þ›I_ì¸R?(|×›¿jîü%xÓ$T1ìjˆàÀ•Û9x~ümy‹Äað
+—1…Á®pUpEªT£æC4Ð,î{KòøQåæè÷ÆÈ°¹î)ô(Ü”ÿC½ºÔ®þ²›Lý	Â$9ý\ñÌòÌŒiæÚÓ"óÊ!§¸‘¸½ãËx«­‡ÃãF#Ô¼W¸ãJù°;‚Š7Fš=íŽúüŒ¼àAIÀóÛäb=\g@
+hG…‹VÇ‰]ôùÖ®“ßm¹k¥æBnü©„¡™HK|7Vßî¿\{¡Iä‹×0|7¼£²Ø6nÏÖdžéèlý²§õ«í–j‰½é :`š†H»Òo2l­Òï”[­?gºMI§ãôÂ07pøïF`¯ôž¹x^ä·Åº‘CU¹%ë‹7Ñk.=è¹|ëëŽâÜ‰=çÕð«17(N†)°<ù—°W‡F aúà`MG·˜pŸÞœ—\¶^àŸÏ]{éÚ§`Âf þ"ÿ§û#	@°îAclÚ	w©»5_½#°Õ6Ùndçz %eLcŠ/—tmÍÍmmææŒÌsFÆ9s«Ä?p]ÒÉvä]v†}ki?ðÄ»EònK¯)PÜX Ðœ’€u
+V‡|TO˜')ß¿ÿaœ);Oäo÷»€gøø…9[}¡®Gøö\qŒ„›é…ëÏI§²äs€¥ªûu©—îYà3xc4HÕÌ©’’*Lõ>uõÇ;¯öæ{~£Ï§.¯›+ ¿xñ<d^Ù‡¶J};ÛfŸÍ¥‰G75åˆ,Æ(m²(î¡bŽJºÞæÊã'%Þi}FïÞ]¶»T°l­­— ¨à­8ç=©»xá­á]i#"{í_£eÎþŸÂRE¡{(Š¼ËXJ²¬k…¤œš$èDŸ13{VýuçJ‹SY¡ÒX†Ý‹)@GØÆgÛ¹=roíÄU:ÞùYUã¾cÂÐþ/Z]¾êSÕÈár0B£¯R\;Ê2éGÉ®OÇ–wJÊ!Ù	äEˆ .þ¨Kwf··;ííÙÎôôììt‘u_â	²¤	èõ¥;¸Geû‘¾#/+@U¥F[UåF¬Ž¯¬ü[ón¹f¢sè':û×h@_©yiåcº ã{¸&
+endstreamendobj187 0 obj<</Filter/FlateDecode/Length 4476>>stream
+H‰lWK®¹Ü÷)ê]â'ùÛZ¼2ÃàÁžY´˜ñýGd$ÙOÒ@€^e‹Ì_D¿üãëõåï_Óõ—¿~½é^y^ø¿Õ+_üòøò·¥ë—ÿ=Ê´k]Ï2ÚÕV»Ë¼þøÏã¿ßéê¹ÒžmÝKÂÄë_¿aÃ<:6lmhÃßùJø—¯žn«u^­Õ»f+×Ç·ß|{”»ÏŠ§×£Þiäë™îT×Uo+…F^£·FÃú¸>°põNsŒyÙñœïŠåz.pcb™,ìZëŸÔ»ùÞ}U3gßÎðÊî4¹.Û¢QÆ¸Ê=÷ã¼Ç×ãWëNkÁÿøBæ‡&³mÚ½ósÞ+!•÷`ónpëãÑáJ¡™Ë¸Â„Gãîˆb .8Ôá2ÖMD–il8ï1±a»~Ãî÷ÀæuWfA¡0<Ù;Föenä»ßTe¼ú7	›"Çeú±xƒU8bb-:ä^È<ìÈKÇÇ‚¤¬ÂŽ­ø<hóØRÍ*ŒÉÊôî¯'+6{¾ä›ž?O¶Ù
+óµÍgn~ö‹	?Ï¿¢ÿù©·FCz«"ÅÈ÷i­gÉwjæÍõ,Æ#V.t2ÿae8Î°·^ïªj©m
+¢×Þ_[DO¯~G–eiëø>íùñ©ÿ_aÉ1íüÝêŒñŠ?ßÎ($áûzÿ€­ÁÛ°YÙMþ„+³´Ï=ï?ë»vÖ±M¤³¯½Q:æã!3Îzms°Y´GAÞÚ)ú¯óãº+ÿâ‡ŸïôC´^ï4¢[ 4òSnKç=í†Èkâg`¨™7õ'¶!¡°ÉÛÞ÷ìëÌº&@Ï`ôæþŠ™âÁWí¶5hÌJÏ²d…´‘ÌóÇ?Õ9Æ@§Àhìà´¯&Ú»ãsd˜À6GCD;( "J2*É!¥ãá¼ÍQ´[$ìÅÏˆ^ýhƒ†Zbgq9°ó“MPÙEÁµä•†“DêFVšyy†Õq·îÔ\ÄY¥2£‰wà·Á¨ÎÓŒmÑg~#ûÂ9³'`]Ú?ÀÏ {24	†Y	ÁÜNK¬Ô•Š¶úûd ´ùˆ`º¢fÏ8 ,}µa/L¨Fª¹ó´ŸLmxL¹àÍ‰P¿g¦LF2d¸Y»«¡þŸÑ@L¢q‹µ¼-[ÞEÀ®KŒäMy
+3•“c[Ù(³©Ã2àÙò±ÐGWCŽÖ»¹áK£98	ÔŠÑpí^Æ¹—ŠÊ—;­ì•­ÍÛT†z¶Õªumd‡„ñ]OÄ@Êùm”>µ°[#fWÙ;¢À¤+°	dÒ0WFƒÏp¸h`ã6ËP3K2£šøhD½§¯°‚tš£zKû†FñžfÛ‚š}æ1Ç%ö`¥YoT@ìê^{n'÷Õj€‡Bc}IÞ  ¢~UTóAI3J#Ï]*‚¦4Pà¬×`Ëh;$+m$.R4¹g xL”9c›+¸`‡2Ò¼ÙÊ1$_(Ó‰nzeÝr&ªÎ•}ïHÑëEÈ¤5y˜'íŠ0Ê í_¢æ=žª“cê®ö²tYY-¸Ú‹>’S7ÑÃ w"ï§H™º°š*CR}Ò!X4F¨=	†¬Zšz¤ò˜,µ¥o:<ŸŒÒ4|C§5ÉPG&õÎÛ
+r‘3t´Bn¹ûp™R4’ï 6ññ+ 0uÛ¼—¨"Ã~>âK´)It`:’r 'z–_à}éD.\ø"+ãCB
+s1qAû"€rtî.`ð‡Ïº)Æ¿vÅÜP”©ìw‘Y¢_“9UÇ¢ç‘8%Çó$Tó)Q<Ý£¹‚*ÊìXÓ'åz“3G8hæºOäXŠÜdšýÏ‰{@ãJH/jß+ˆ™‚:LEtË›º°©Ÿâju©¬:];æ°¡®"«¬]fol·µ­+à9ìgº§e^4¼%ÚŸü ùé¶MõWõƒ¦z\üXÃ¯·ÿeEwŸCcJãÐ%M$JŠ&ŒLµ-¶dV”ê¹ã w›¡˜5ÍïòšÄÏžIÎY![Ç™¦d@|úfÙt4Ív¯A“š­jÆ¢:Y[z®áUUÉ1iQ½^ÕÖa¥×â`éVUümŸëPBód½	ƒ„^Ø‡®`’VíÝ¦Ö<¢‚”Ù,Øïð'sí+e:ÁhÅð‡ê(¼xŒ^ÖBÓ«¶æýTüÊËJ)K{4“Ì@¦“.)$–3úFJê[˜dJ%YGu+iSÂEòGUõXZ%62Œ9½9“¿™®úÙÉ‰wÞ©<q*…NHÏ¾4e¨A‘õ—GºÛÑeS$dõX»ü2¼ë{ÞŽÅ¼Q•c)ö<s¦ös­å¬Ê~—“E¢w'4¡HYÞ›©Ðp@êT°A?´Ï{BGßéê@ S-ÛòÎ/äeÔ òX“ qjœ«GB¿˜€Ù¦’Öý"ã3r:Iä~ È´¾¶*¨WPõD_Ò0;F¨(_¶“‚¾{žë„ßBBˆÇÓ’†ÈGÅÃ²Vv2ÜÕ4Û™ö•ÊÎ™1½ÆM¢ç®‹ì[IHßùÌ<–3.+°ß"-VÏ 2ñ‰£ë`3‘µÇWÜ;fîp¥´5êe¤4&=ÆX˜ž´8ŸQÄ|Óæsõtî7«où(‡Á…+y#O‡§Oúm8ÉhÌ<BŽë»×6÷…/èPæ5éê;„ÿ4'2²6®HuË'þ.º–|ôÙæmUmá°s?‹Ç¸f¸eÓÏ¹ý°‰Ò‘U»¥”Ö°¼ ®iâ-êÚ› çÅ·qä™8qÉGUQ iˆrÄ£9w ÃÆä iÆ êO/“íý¢¹Ò©	ú73Í³Œm´Êq®¯(ŸÖ>€÷›®x8¹MêYW„þjP8ŠtwD	8ÍµS0À-+ò#&Ôl§ÕŸ^Ó^'ó%½˜*tˆpè“‰7IÊ%A@þ²+­ðéë¡öƒG³^R ºHŸ-´IŒ{i!µbOèB·8Ñ‚2jŠˆè‘¼¿Pž¹Eë‚+Á¼Èaÿª»rŒjT£G«ñ0Ôb°˜Ï ºÂjPïºt.~™åX0öºÓÎÚCP9y´1÷ÉŽön¼­[w	šeº6¨åâUà+òØ„#‘›(°~¦›Ù+Z¼‰ûHA+ÂJ8 b¯¹Rç~t\Ã}S^àAþ©¸6îŒ5ƒøYœõ›DŽŽôL0ø%bÏ]÷DT¢ù%!¨ËŒÚDó¾h 6ÿ²þÌTnª¾åÀšÄ!þ&Ñ‹ØÈ…à“»Ê‰V5>fW«k?ffÙÞ¢È;ªœ-…'—cfÃ®9×ÝJÚž³Ëåù\‰À¶PŒnH—	ÝÙ§§›äÉD4+JnpÍï:„¤<CL+î$1ýUÿ3š%ã–+ü§ýðùrãvôŽôöSM¿Áû„ï ÝH÷¥ÆúŠ‹±d‡dòr•OÞãÕÎïY`Ž¢uMš[[ëAqˆ–˜i	4àÏÅëíWUìàD¯SHÀƒ¤HNvñÝ6{b“Ê^7ÿz¡ãf†êÊpBXhÛ·YñîŒÔ¦ç¢ø¹"¿§ßë!QöÜmè2H¬"fZû?éå¶Ü¶„á{=®2R'NA‚ €™NgbÇi›Ä9*=¥-ÑSêP‰r¬>}÷ ‚ yœÉE"­‚»Àî¿ß¢¿ÎÐBDd¤<QR4”%ÉKE¥ft˜2^ù48ëð Æ£¸šò‘s6¹ÖÀœ4<ã ©)qÅe’îxRB?4
+Œ£ä4¥"IË©s†9ë§E8€IQïœÕ<³r¢påvÐ2)r­YwfJÓ7[Ùb“w€ï)V+e8t˜Ì…ò†æC#–Ê{*ÚY¥«é“€DVrØ3\•Ÿû2Lw˜î&Às€®n,¡Ü¶aêhJfBª3k:¦†Ã1y¨[9 ]mk£Lc»nm.Êzà! 2³ö^ °LÚ¶cÈJë=@	Òº-ôPõ¹3~Tä!Ï-ÑÆ·ö–¿ss¢g°Ô2ãî*¬g¬‚Ø:t’±Tâ@¢0Ù±·œ0»1*‘‡)Ì8CP.IRÄut“koÖ­y)’¨´;¯Ã˜äèÈtî"Û_Ž'=„Èn4ñÚŽ1ÜyúÀ| O±ùZá^€¥ƒ#š¿ÿ„¦^æC§RÄ³¬šü+oOš-q^Mc"mÃ3,¾'ÆFQXŒâ{8¨Õ«°ØþÀ@úÎÓã‰ø01¥\¥¡Ù8.qj$ÜË}îÒ:á—0Ø¦®Ý·x}>°¸ 5×ÏH‡?„ì:¶$Q’ñ‹ènàÄK,Iœ\™¼÷³¡ƒ
+æü÷1Œ3œ©†è‰ª>ðäªÜ¿n+H©%ø2BåGJ}B¥î(C%C™ˆ¡l¡ô—*ï1”º›¡P®mPóE°c9·==O#=·==Ï"=O:=jŽ„¦#BS¡é˜Ð²/šŽSÏ«"ÇÇÒGòézä•và…Ù-CšGµ@v^iÇ]¸[Ì]X¥wis—ìƒþÈ+Ë:ò¢ù¢#/Œ2Fß‘œKL^&ÈËÅèeUŒ^Zeze¶C/¼½ò¼c¯Læ|ÃV_Xh-|ÑÙÁ¶å¾Œt|qÍ{øb-gøò|ØÁ—íàçÛ¾<|åY_.¢/~º£/ðµ£/§{ôe“Ž¾RÁ—V1|àË*ÁWn{ð…>ø2I_Ü’|uJç“¥¥¯Dº}e<LvøÅ‹/î,ì;ýjæÞñfp:Æl4,bÐ¢Äf6ø~œ|„þ%Åøj Xo€Ò6b<|ÂÎb<2Pàb¸_¯f›b=ßþ?C§-1Eøßo
+šâVÒ+:¤`êw{µÛˆÉj±.–{Ñì×åU1)Gª ‚Ã‡âõf5R‰ÞT‹Bð;À}+ÆOàÑ—«ëâ¡˜[qY–K±-ërÒ”SqµÚˆªùrn¤õ”nùáñwƒá¶Ù×¥x êrV]VuÕìE1Ù¬¶[±Ü-ÊÍjkÇŸhé´¼®&åö¡˜V³ª)jQ¬×u5)šjµÜÂíºÕ®YïQ-ÅzS-›Gø;ø	}üìNÃ›­@¿WÍ\¬àn‡6/‹i]-KˆeÙˆb9¥UM9R)ÍMÃzÐVmÅnáƒ×Å¦Â@ð@?—ÕlÞlÙ©ƒ{>“pÏ	Ý3vCš0%m†ëùAzJ™k)„)Ø§`[0””™û)Ø`æð»IüZø49¯I@<NÏðóGp 4ÔÕú)QœÓÞÅë$®;1–Ö	æù‘=ŽŸ×¶—:zœÜC7r/5 Ãùí¥äY†oóŸ9>r>†l]í&ó÷ëãò¦9ŸV¸xMB»ùtNa[Îf(úñ„Y¾} .ôVÀãÀG8kh–ÞüaøøôìÉùÓŸ~þåÙó/_½~óöÝòsüþ×ß~ÿãOºKÐG}‹B—“iy5›WŸþ©ËÕúßÍ¶Ù]¾Ùÿ‡7
+M Z§¬2ë8Ñ#ö>tâ`~CÍð‚µóQvæqv¾À„!W|í¶Ùq#t.lùY†âŸ1”ÜÒQ®Ý3ÈeãžQb‡†§,RBÙ+Á· bXÎvu±	±ª;b•pz
+Úô'@@´ŽkCU_ªr÷U"•Ü )Óº„±¦öQ/Ú‹rZí!NyWœˆ… Îi*i<9&Žb‡‘f_©ÉE]Æí ¥Al…ÎšCçsîxÌïÊEu¹ª§!êì®¨±ÁÁí&«õ®Û5ß³R÷.W©1q€c©ZãËÍŽ†	
+v~q&ÿ0 Ä<BÊ
+endstreamendobj188 0 obj[190 0 R]endobj189 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj190 0 obj<</BaseFont/NBCTRX+ProximaNova-Bold/CIDSystemInfo 191 0 R/DW 1000/FontDescriptor 192 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj191 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj192 0 obj<</Ascent 1079/CIDSet 193 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 194 0 R/FontName/NBCTRX+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj193 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj194 0 obj<</Filter/FlateDecode/Length 1407/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»"ƒ3[ŠŠY4B|4
+b¨Rå¡¨ ‚,°Ù•Ç.øZbÕšþE| Õ" ²Z( `)Uk@k[b}@©ÄªHC£õÞ5ílMú§ß¿ûÝ›sÏ¹çæ’„Êƒ IÒ;vIdB\Ràª|K±yKZ¬Å–6k‰%7Ã‘Ù·L#ÊSIY«’EÎ¥s©|Uç_÷Ñ¾ª.¬ñ„½^°S3Í—®×ø4IªÙå	–tSt†)¯Ð\Xi±–ä›³²É›“gV¦åçâÍ[,y–¼ ÃœÐ`CDn®áß¢C¾©À”o3e—Å'”XM†¹†Sæÿø)"&¡%ôD4C¬!6©Ä&ÂDd9„•ØJä6U'EîZ-¡UôÓˆ ¢€('î““É`2…<@¾öHðhõxN‘Ôê$õHå¯ÊSÈž]7^SGÞª‡æJ­Ào¸S§ÃæñhV³xœýÓœÙþP	Ó¨FÒaø¯ñ7á¡Žq†á.ÊzôÌ
+
+ÌOðlz6ò¬)=EÖPe7ÚIØP0ª7â$31ëAx M»ŠöaxÉ‹”n²?øSr»¼°žåÀ=ýÔ>0éûè`Ì¢/·]«ë¾ëÎ[=á2<‹)ªö^•Dð‚zàÊì<?þ®¼Mâx…Ê˜ÄàIW(*¸ƒ"•*ŒRóO 
+êi÷¿%yü(Èpsô{cdØ÷ºîõÊÿán]rGoÉm¦Žþs$9ý\qLLzÚŠsÍ™­"Ê §¸‘¸}ãÑ¼UŽÔÃ‘q#ajÞ‰+\Gp¥|ÄAù#ÍžqEüþƒÃ/¸ÐB"ðü¹P7¦·¢ÇâÅkW‰aôÅæŽSß}-9ë¥(æRNÜé„E!éHK|'×Þí½Zsé¼È®cøNxGe±mÞ™.¬K?ÛÖÞüeWóW;-U{Ûôô1hÂíJ¿É°´J¿ÓnµZüœé4%ž‰Ð3$ç¸C7{­ûìå‹"¿#Ö¢Ê)ÚX¸Iˆ\wu`°ëê¯Û
+sª%ö‚cTC¯ÆÜ 8¦@)xò/`Ÿ@ÀŒþþê¶N1þ!½%wMÉF>ý•ŸJ€µj˜3ôù—8Ãi4Hp‚tƒ±)%Ü­î8ÜxýžÀVÙd»ý±ë‚ ””1)¾\Ñµ46¶´˜ÓÒ³ÍiiÌÍÿ¤ÏuE'Û‘wÙö­¥½ÀSçÉ»-½¡@qcÓæ”lP°ÚäczxÊ<MúþýW™2sEþn¯ x†oƒ_˜sU—j»„o/FIØÆ°éŽQ¸ùœt*K>XªªW—|åeP Ÿþ[Ã Aªz^¥”Xn*¯ó©­;Ñ~½'?÷œØõ}19¦v¾€üÒ¥yeØ.õ”¶8Ì>[¶'|yþ|¶Èb”â‘Ñ&kâ)æX¡È¡ën¬8qJâÖzÏž’=Å‚e{My£@ÍoÅ9ï…HÝÇCoíHÙÿ-söÿ+
+ÝCQôà}ÆR”a]/$fWÿ A;ò8ÂÌêZý×½kMNe…Šcv&fŸkçöÊÕ¼µWëxçg•ûú¾hzvùº7NU#‡ÃÈÁ0¾jHrí*I§·:Šv"8¶<T*)‡¤ÂÈËF]þQ—êÌlmu:[[3©©™™©"ë¾ÄdI3½Û—nãv“íG{Ž¾,U¥m•G±*,´¢âoÍ»eš‰Î	 Ÿèì9tB£}…æ=8¬•ëþ`  Þ¸+
+endstreamendobj195 0 obj<</Filter/FlateDecode/Length 9046>>stream
+H‰lWK®¹Ü÷)ê]â'ùÛZ¼2ÃàÁžY´˜ñýGd$ÙOÒ@€^e‹Ì_D¿üãëõåï_Óõ—¿~½é^y^ø¿Õ+_üòøò·¥ë—ÿ=Ê´k]Ï2ÚÕV»Ë¼þøÏã¿ßéê¹ÒžmÝKÂÄë_¿aÃ<:6lmhÃßùJø—¯žn«5_­Õ»f+×Ç·ß|{”»ÏŠ§×£Þiäë™îT×Uo+…F^£·FÃú¸>°põNsŒyÙñœïŠåz.pcb™,ìZëŸÔ»ùÞ}U3gßÎðÊî4¹.Û¢QÆ¸Ê=÷ã¼Ç×ãWëNkÁÿøBæ‡&³mÚ½*¶˜÷JHå=Ä¼Üúxt¸Rhæ2®0áÑ¸;¢ˆu¸Œu‘eZÎ{LlØî†ßp†û=°ùÇcÝ•ÙCP(ÌÂÏÄBöŽ‘}™ù.Æ7U¯þMÂ¦Èq™~,Þ`Ž˜X‹¹ò;òÒññÇc `)«p c+>OÚyA¢Yƒ1Y—Þýåd½fÏ—<ÓóÇãÉ&[a¾¶ùÌÍO~1ÝçùWtâ??uÖÀqÓÐY	F¶Oc=K¾S3o­g)(/ù°rA˜“Ù+Ãm½íøózÿPUImSÕ¸öþ²Ø zz=ð;r,K[Ç÷ahÏ‡Lýÿ
+KŽi‡äÿèVgŒWüùv~@	Þ×ûl=Ý†ÍÊnñ'\™¥}îxÿYØ³³Žm"}íÂÐ1™qÖk›ƒ­¢=
+ºàÖNaÐ?Ð]ù?œø|§¢ýðzw`‘ªpF~ÊmÉâœ §ÝyMüÇšyKâÒ	[¼Íá]Ï®Î¬kðFoî¯˜€)|eÑn[ƒÆ¬Àð| KVHÉ<üS±`t
+ŒÆÞ JûZa¢½;>G†	ks4ÔI¬ƒ * ‡CF%5¤t<œ·±9Š¶sk€‚½øÁ«mPKì,.v~²	é"»(¸–œ¡ÒpŠHÝÈI3/Ï :îÖ˜‹«Tf4Ñáü6ÕYš±-úÌad_8gö¬KûøtaO¢S&ƒ&Ã0+a`!xÛI‰õ`ƒÖá@qÃVŸ”6LWÔì„¥/°6ì…ùÔH5wžö“©)¼™"1ê÷Ì”ÉHÆ!jí®†únD90‰Æ-Öò¶ly».1’7aä (ÌTNŽme£Ì¦Ëx€gË‡B/4]9Zïæ†/æàP+FÃµ{§^**_î´²W¶6oSêÙV«Öµ‘Æw=)ç·QúÔÂn˜]eïˆ“®À$=
+pHÃTe>Ãá¢qØ,CÍ@,ÉŒjâ£õnœ½Â
+Ò5hŽê-AìÅ{šmjö‰Ç—Øƒ•fi¼QY, ±c¤{í¹ÜW«
+õY4&y€ˆú=VQ}ÌÇ$Í(	Œ<w¨šÒT@m8€“^K€-£í¬´‘¸HÑäž øœ¨r )<È6WÐa2$?‰³•cŸM¾P¦3ÝôÒ ¼åTT,ûÞ‘š'@*Ú	 ŠJkr1;PÚ;”Qû¿DÑ;›<UgÇÔ]ìeÉ²²ZµW}$çnÂ‡=@ïÄÞO±2ea5•†¬ú¤3‚°xŒX{YÅ45Iå1YbK5Þ|x>¥i:ø†`OkR¡M
+ž·ì"gèh9Œ*àr÷áú2¥è$ßA}âóW`ê¶<x3QD†ý€Ä—èS²øÀvdå€O4,#À@ü’‰\¸ðEVÆ-¦„æbâ‚÷ÅåhÝ]À vS”íŠ¹¡(SÙï"³„¿F3sªFÏ#J…TÌ“PÍÇDñtæª(³cM•ëÍÎœá<¢™oè>‘d©q“i<ô?gî‰›'Ò‡Ú÷b¦àSÝò¦.lê§ÈÚc]j#«Î×Ž9l¨›eöÆv[ÛºžÃ~¶!|Zæ=Ã[¢ýÉ nÛTU?hª÷HÆÏ€õÑ1Ìðzû_Vôw÷A4¶¡4ÝÑÄ’!¥hÂÈ”Û¢KfõG­ž;ê(X3³¦ù]^“Ú3ÉA+dë8Ó˜Ì# ˆOÂ,[€Ž¦¹Ñî5h’³UÍXT'kkCÏE\ ª*9&ñ1ª×«Ú:¬Tâ^C,]ªŠ¿ísJhž¬7aÑë¡2ûÐÌAÒª½Û”ÀšGU2›ûþd®}¥L'Í£˜þ…Òhôª°š^µ5ï§â7^NPjYJØM-Ì@¦“.I$–3úFRê[˜dj%Y˜GuKiSÂEòGUõXZ%62Œ9½9“¿™.ûÙÉ‰WÞ©<q*…PÕ´ƒöìKS†"YÏq{¤»P6EBWµË/Ã»¾çíXÌåQ9–d`Ï3gÚh?×ZÎªì—9Y$zwBŠ”å½™
+¤NôCû¼(ôqžî0åÒ°­ïüvq@^öG2U0)§ÖÀ¹z$äØð›	˜m*iÝo2>#§“„@î·ªLëk«‚zUOô%³c„Œò•a;)è»ç¹¿PAxð-$„x<-iˆ|d<,ke'Ã]M³i/U©ìœÓk\%zîºÉ¾•„žÏÌc9ã²û-ÒbõÚ Ÿ8º6Y{|Å½cæWJ\¨^FjcÒcŒ…éI‹óEÌ7aŽ1WOç‚³úÖBq\¸’7òtxú¤ß†“ŒÆüÇ#ô¸¾{msßø‚eP“®¾CøOsq"#àÁ½©¡nùÄßE×Â’>Û¼í±ª-v.ƒâç`ñ×·lú9×6Q:²j·”Ò–Ô5M¼E]{ô¼ø6Ž<'®"9à²*
+ QŽx4çtØ˜$ÍDý‰ãe²½_4W:5Aÿf¦y–±ƒV™!ÎõåÓÚð‚Óu '·I=ëŽÃ_
+G C‘îŽ(§¹v
+¸e…à@~Ä¤‘:°€í´úóÑkzÃûd¾¤÷R…}2ñ&I¹$È_v¥¾¡"}=Ô~ðhÖK
+D7é³…6‰qÏ"-¤Vì	]èÇ "ZPFM=2ƒ÷Ê3·h]p%’79ì_5bWŽƒQjôhõ †ÃCóTWXê]—ÎÅo³a€Æ^wÚY{*'6æ>Ù±ÑÞ·uËá.¡@³L×µ\¼
+ÜaE›p!re ÖÏÁtS#{E‹7q)hEX	Dlâ5WêÜŽk¸oªsÀ‹<È?×Æ1„šAü,ÎúM"GGú&	ü±g‡®{"*Ñ†ü’ÔeFm¢y_4›ÔS?3U£›ªo9°&qˆÿIô"6r¡øä®r¢UÙÕÇêãÚÄ™Y¶·(ò‚*gKá	äå˜Ùß°kCÎu·’¶çìr9¼c¤³`[(F7¤Ë„îìSŽÓMòd"‰%7¸æwBRž!&w’˜þªÿÍ¬?·ò[®ðŸöÃçËÛÑ;ÒÛO5}üïG¾_€t#Ý—>Hë{D(.Æ’’ÉÈU>yW;¿g9ŠZÔ54inm­#Å!2Xb¦%LÐ€?¯·_U±ƒ½N!’"9ÙÅwÛì‰N({Ýüë…Ž›ª+Ã	a¡lßfÅ;¸w2R›ž‹âçŠüžR|¯‡DÙs·¡Ë ±Š˜õÿ´W]ocÇ}×¯˜G»¨´óýºÛ6hÑ>¤+ › ÐÊwm5²dHrÒí¯ï!9÷Þ‘mÅ¾h‚`-QrHyxXaü-‰E&–'+Š%Áe†<kÔA°PÉT8$Â(Ùª£D
+LV¸jeˆRM¥¨&“ì8$:¦”d$Ps%3¦@6%ò#Àž@%0±ti‘'ç0 ©fë6ã˜„ÉñìÐRÕ²³J¡È|•q3PK(*½¸EËÛA{ØQ,à»¥nå
+Ç„ñehoÞ¨]Þ­êw•±§ŸáœÖ´ð!Ñ¾ÐÐ(gdÉÔâ×ÃzGõžö<°šÚ‡DÇó@n„vô¥Bn´œFRì¤84n}€W?Û¸ÔDÞö²tåvVY@#zAíY´V²ý@F]æê0¸†}«}KªË¢¬”9Râ®|—ñÄo.Hy øTW™+‚h‚ƒ4<‚ñ–´’8*wš.saoB–ØC‹m‚¶®&Mkj*C†Dà™žb¨â¶ç(ãì˜°ç?—ãœ…X¹¾NåzD#Çå¤Ñ~‘‘A(û{Jã¨v‹LjZÒjÞ{k|X›‘r«7åWùÞgZ$q9Í‹"›‘-–n£]Dˆ£,)Gí;<ëƒ@ºq Ÿ¯Œð²?Î+Ä;“•>ÆM‘&çQ"Ó¼/ç°¨zD¨­-½Ýí¬"ô3Ùà¡nÝ’žÿ0”?øqfÒBÀ˜áæu]P’âò¹ñ¾n‡)õ_f1%I¥&æOÜöB­j%\èÃÓ´L‰’½L¢âåþeËEe••ÏXTx™EÅ3å~žE`çÏï¹ô|†è¶Aô|ÑÍˆèžGGsG-Gó/s´Ðp4*½ŠŠŸ@Ãg9ã^v¤^TÝz(ó¦X©—™Yk™uiÃ¼Bh™—>§^ôëÀ½¼¹o#÷¢(îEÑÜyi¹W²÷*-ùÊ®%_Áù†|ù<’/z–|Å8²/¯cC¿’ké k¤_Ôh=ýâ-r¤_4—ú•tiè—ô|¥_‚åB¿*CéWém¸-ý‚TéWôý*ÿí‘Á×‘•pÆ¿²ù—uý
+®¥_)ô+»ÐÐ¯˜Ïèù4Ð¯dú%#i _#ÒÕbéù—ÑåŒyY'G&KÍón–Ùñíìý’ª1	ˆaD©ÃíìÝÒüóK«å—ˆn@kGµ¼™}º‚-õ·kƒuµ¿Ý«Ûnu8>¬ÖÝõ÷Ë¿’ë™™Åð·ŽZ2¨+®G^ÊØæ_NjsT›û‡ýá´ÚÔi¯~¸¶hZ`áU×=¨õþ€ÿ·:uJî@Y-ÿÕûÕá‡ë¨®ŽjM~¨ýµÚ}UûÓ]wP·‡ÕÃÝf-JËßàx·íî»Ýé¸PËkCA 5®öêÐÝ>nÉüénsü-,¨îÚY¹ÿ?×@þ«õöqÞ›¹:nö;õßý®Sw«£úÜu8<­>o7Ç»îF]/ÿÍÇV‡ýãî6»& r·ã>×„BW6×—lv7›5tbj»?â¶'™¸zuUíê¾;Î{¯Ž«[AˆŸ;õ°?nN¸NovÈr@·"ÿýiº‘\¦ÄÒwúwüzÿy¿U›Ó±ÛRºÇˆ÷„zÿ@ÎìV÷úÎâ¡ó™ú±S«þä§«ï0{%V\Þß|¼Û<àøê¤ŽwûÇíÚu?"¢!ñpy}·ÚÝŠ¿tËO«¯Iä³"þ QÄ†‹˜Òä=¿6rõ;J­uZ'ò{È‚ÓÚÈ†1â÷dêY|¦(g@ñýúü=îˆ‚%”€¢§èîå=.“ƒšÎSæI<§V¸!GüZhÑX>4úì 9u{6aÂ¤ggÙ9O÷ÕÏH:Z‚Îh0,«Ê‚€ Š‡nöOµ£êÿîÿñÍŒ66¯~R^ý]}ÒÈ¿×êFÍÞ}óÑ¨ÛcC•¼‰„•ðF<Þb J¶€e i5`êã¿•¼£ô˜iJJ4œ')]¬µž¤Dùšx&Hw~’°c<MTÊP*˜¬“”È6²~Y‰Ô¼N< mÄ<ÕvPwXNd_Ê´2\@æbÙ@emù²R|Ëµ|+1='‚—X•):C=x?E'h´ZdMÑ±D:ˆñOÐq`-	½3E0ˆäLÑ	ÐÑs€\ƒZ¸I:‰x¯–·,œmŠJJÔ“R°Åæ'¥L°™'ùþÒç&¥::"¶iRª#ÊÀd3©}°›a†IÝƒkrÁ0˜¢ƒpŠó“ªÀÃµí¤'õ¨¶Tô´xP:É”Ii(ƒèß’ à'¼…i³¡!-v´ÒêÏ«[€q¢ðŸHÍ&`}ÀŠ@ß5ÿ½«W	Ü>‡Úæ½#íjyÒãE$<dZo¡…µ›ËÒ2éñ’Æ²ÃúäÛ7° Œ.Êñ‚pžçW¨Óëi)ëœ„{ÄÒrX50÷ÂÐí•x¼íž(™Q	o›3®=ÓŽ:H"Šˆ²ÒÒ¦Wn# ~Ñ†[Ÿ[žµðXðÀ
+,
+$½9ýúßïxe|ÁžÃ®TÐ?£½ª8,Î{“rÓüÌ$¹Œj…ËÙ’ËÞæ…†ºÃÊjÝoëòïôEÖVCŒ»Ù.‰èGv-‚FŒêB\Å Kaô»Õ¹0m¼àG1xe
+˜£Øj\xškâC™]oÞ™-ÌÎrÈžÝ0äÆà)rç~³!ò/GÞÑ‘çÖ|<©8>jÏ­šy¸tfM½9ð³—8/ÿWsòq|‘Ëgn“¿ŸÍW
+ö•tÀ•7¦+…˜_I×`íWNWMA“.BJg_/·§Æ‚þp„|Ë+ƒ†óùå
+Þ Y.—Á³OÑü
+åõj^ÈÁ¯Å'µÏºôj¾ŒãEÓ[—/åK8¼!£ùµ|‚?º?¥Kù"O[k¿h¾.æà…vlÏö¹uoiGÉWx!_C?J„9½¡9_N¿¯¡Ï¬ý¢ýx1iMðd°z=¨m-Í(˜ÔŒ:˜KBÄ Yh´9Nb¡ðl‚u$xþ"g~N…TY¢UIÍ1¤P–U°h€„sU„YXÉ#ÙÈ$Ö¶LBlÎ¢W!@8sÚ
+åÝÄ^XË¦¯4w!`4´0…ÀJUÞÂbqa#"'	Y™K”–²¹ž%L~b¨‹b’Ê‹”2	N!½xžŒ¿ *3äð?a*#¹x%ë™ qìfÆY<½‹PB]Ñü¦ë+*TÉ"•VÎ²¢‹¸zM¦cM4!ëÖŠˆ#DŒñH¨18êðjT”s+Xð ®¡¦L‰Ôìñ–xQ²ü2§Àÿœ¸I»˜ü‚x¨|_ÏŸ‡Ï"n{qnp‡6ÂŠ†ïO¹x‘5<%¾g¨ nEKQâ’›ÛêWð}ÎÞŒ˜éÉE°‹©Gªˆ·
+…µD.¨£zµjIWÌW‘Ê¦~ÅÚƒ¦a=»ÞHä†õ¬Š|ÿ¶Jâš˜Ðü<|$bò ÷Ãxa—‰!? ·T”€¤]-þ9\	Ú6­s/mñJÅ÷'#­½‘*Èë™ˆÕ…m/¢)?ž§y±ÈÈ˜¯9/·×ÈWq®þ0'¦žÄºæ÷Årç8<@g Â/àãr³…$û&à‹D³sÌ™0ô%.~MÉvø¦5g£¡1aM”q +zóú‘ÖŽ.¡!;Àš¹| ¸‡\>˜Qæ8ˆ–uÿã¼Üy$É ì÷¯hS2jï‡+-h=2Ð9½ŽîÿÊˆH²Ø3sÐAÎngO5‹LfF|¹B+ï1ñ`Í>L¯p6œÔt`ÆÂ"©‡ÞÚÚ!„¤ KáËØ¢bØ›&&[½}Š!NÍÎùÒ/Bùê›žñ/"Ç Å²k•¢‘lB°¨šXª¬ß°+èDG6lçÃ~ir1dSdËpa[Yµ£÷ì‡'¶/­Æ;ÇTÖw ð¨Ü¬x®Yb,°7ë³=f.Ñ!P¸K;xÎ–€dè–ö{í/7ÇâwwEþØ=Ï'“2S#2ƒÆý"Öz÷Ÿm¸•§EÝúA¢†)ªÍ©˜Òú(å­ «5<2ÈBK°ä›ÐØš5úAæ\IËÊR.ô9&³J¾¬)
+¦Z[ãsÃ´Ù2ÍAv}7»J‹b¨«½äú7Ð‹ÕCËº¸Jc#˜ÌC*le[Ñ3ªlm¦bŸÑÚvŽ|st=Ã L_Ïn¶ñ½Á.‚:´¿líhƒ¬	»¤r¶-SfG«-JŒZJ!o³[ãêÔÆoØÐFU¶~ïjv ÃBëP«OXÖ
+¸fÜ‹jr1au4N-ÇðvJ+OíR_[d	lÄ_çt?ÙXG¡_‰ýjŽu	`„âyïXÞlóÒèšˆ [±)[jÁŽã·N¹h¶º-;Ä€¦¶¤"À€'®Ä¢’q	÷çÌ2Ô“Š)v”˜‰ë¯z66D¡E½{²¾ dxwN«!¬Ö¬;ï·èê0jP@ND·¦æÝDƒ
+Y•q0ë`HàX‰K²© WoŸË5W~©
+­u¦w6¤õânü¦Ðib×eêôV[i1¦ßñ’B6ç¥–á£Z.÷*BEÐsZÁí[c+)»Ö‚™hCÉ÷T$pàÄ“³èÄÞ¬£ºûâòÆðŸuâ¦E¡¹¡@‰½m¼^,ŠM÷]•,NEŸJ·ü AÜ­BZKõ`-²àUºûþ(!ýé–wyÝú…)âY¡ˆë¯J®ªÚMÚVh*ŸjÖHDµÅÀûî–µÞÙºÆY·gÒ"ìP‘A$ûHT/	­ºú’«~%ÞFÍßP×æ	kJôñ¡Þsðúƒ^6“˜ºh[™E¤~Vb…×‘Ë©	¼ >|d¨º»6…u_PƒØÆçØ(uðÛªO_ÈC§Ê:š‰UT£Pex‹¬3;úÔ”j¦5¡Ð‹Û‘G"Ñ°PKÇ*„˜!è†öªÄ´~÷fÅ6’P6‚³½Ûb(e§ÒÝv¿®ªÅ~Gë¦UØhš«éy1Óha8>û,„¨.ä/'GJÜ
+QËª-ðþå
+«ÉLâUJÎ.P’V3lÝ °SSØ«xÏ¸Ä—)Ú«:nÑU“à
+Hí.•z”!¥¦Ó]ï8aŠáNa‡^š…©>
+âõÓt†‡®–úUxÒWq^7ê»ŸJg^™1å§T§É¾EÉ/7K{Êê†hî‚G¼°J‡Q.\•ó:d€D-ó1y·Øu#È$Í,¶Êª ¬üi¸á'ã¡Ãj¹ØU`¬^ÿ˜FÛÏà¨|¦`.€æ¿Dyé)Õºä‘Þz¥©A©·oÑ¥dRSÅe%<Wå”R÷£ÉûúQ³¬qõUne8}y‘l.Ãi2‹^žc÷)ÔQˆÖÆƒÐûL ¸ZT;˜µæ±#×)=ì_Pü·×=ÐÄ6W¸‰1§ô(kÚˆËH-
+’Hä„wÜJÛÎ/ÊT’tfXlöšµh¸»w]aå£þ.ÝÃ-ÇI™g–!)EÖ³&ÄV–f_bg­™‚moY±2d’¢&ú¹Ž§‹Ëœah©òýv¨oâI¶³þa­¦nîËgôXµä‡¸H¿zy´?—D…ÞØÒ¬·.ÿdŽÙz-[žs0¡éíÝ™’ýZàòJ‘§«,˜KR‘ŸK¹+y]
+´ç Ë‡Ÿ…©ª'w5E¼MAŽþjú®ÚKNz£„q¦ÅekÙŽ¨dCjg?îQ–*D~t½ÞJ¯PÅýBýñ+1’¨Ð³»eWqö_9JiÅ=úèåý¹†°g)Ïf§„û9''OÂ´òìÊ2$)õäA	âÊ¬‚Ínþ7Í—Àÿ¸¼
+:$ï€+È±k¥ö¤àŽQ½P/Q*êh[šý)[tÑÐR†Aæ¨›²¸gÚ+f’hÿÁöm»VðˆªÎÅbèÌô€0d”äÓn±Õð¦>™j.Í¶Ml¬'—*œ×mÄ…LGÑK¸‹$+µå0îÉ&Vä$âÏîòö•¼g<©>ähÞ+»ÌHÉ\Ü• ¶±­¿z+š ÄÅiÞWÐ\ …ip´sX¡ ®ww¹Ð¨|:é ^ŒˆÍËö—ö‰àtHÿ÷ð®£ÁÇÍ±ìêàykËFL<TZ‚àEâ~‚q0ùðJ1ÑÎ„ˆkäQåd§$$ÁL ×3n»…«ã1¨ÝÄÑæA+q|³b(Ó/Ö
+˜R  TÍ,3ÀÈ•×~1]Åâ!GeZ\¦þÓÖŽ4…!Lð/W«v)ŸY>æM9y„¶jâ¯H)‘ñá†íŽÄ2J­15¶Ì…ÛÞÄ`>´8¨¶i‹¹ªCXîáÇc¯!ñøMãü²ÒøfNHBW~0NÌ›ýy,\0E›xÍsÔ[‘g"dºï\¸iíäoQ€›F^<¤8\„J§x»ð‰CÛKØÕPrM<ÏÖ‰MŒQXÔÒN
+òËæðF]i
+Ô˜"Ó…æšz]’ìØÍºÍ"¼×"è?–…<Lœ\ìæ³8‰þµ‘òºæýx`Ã”
+€4hÓJÌ4ŽIwÈMçË“6ˆ¹ÄX`©œ¨ø~<š LOØ^‹Ì'çUT
+P™d(…Îl´'Úið©Ó<ÎìÕ§8-¨0/‹VŠÃÏ‰÷øà#Äs¤R3 HrÌ>ÝzÁx™~|šÆ´>Vü:b4Ä/%óX¨kA™¨:”»D4ïwÛ7ÕHñŸÏ=ÙÜ-þIü²ÝA°XvŒÑœXÅNz*ÚPž4‰Y	4mfñ‘Ûäœ<Ý__Ã-3îC-&6iR—î½L¢m‚Wµõz“û…”=|­Ðz'ÁÂ‘êQîÐŽš‡X<M–
+S=!?n¾f÷¨“¡-r.š¾‚y®xãü(¢ž#ÝÉu#¡¸ÓôW
+­¨CdkŠn4p,„ nÒ(¢UL¬AP|q§”æÂT#xòjÉl°šgGŸeøVš
+_+Ä³—;]Ÿ¿0þŠM	¹±_Œb:0ë»«¦ÃY}îÔ\K›m“AúØ¢J§„î>­9¬þ3ä1°lÑ´g8ü3x)´óÌ@¹à“™â¦5´Zì€e6{È~Wh¥iî[øTÿ¦h7‘£©Ç³£þ©ô»·Ë¡Êåcû¦³¹üã]`·’)hñX1—}=.ÙìÇÝÈKÑõù9cä·6øðo&iÄ-.Jª,õSÏÜ¹sÐ¨q¸`† ð&¨kó¥"<åäâˆY…/Ø5üo¤*R¥7¤Š7RÅù‡˜jüSõƒ©ÒÁTñÿaªr2U>™*/¦‚d÷%é?wü&éý”ôñ%}œ’Þ¶¤ƒÚòAmý ¶öFmñkj‹›Ú´©Ê*p7­Y£O:qlµq7¸>¼áâßÁ1Ñ‰c!8Æù`ãX‘ÿ/ësá˜v°iãÇAc"&HN¿i‰9hl¤|ÐºÞq,kBÛ8ÖËÍc( ›ÇF>yesðúlóXÇ»Oê,CûoëHÕÍcÕlæà±‹y<ÖæÕvòX¿yläyòXÉmñX'ØÜ<6ê	dQ|ì@6Æd©œ<Öb¾y3ÜÍcu¾ñXo7%íÊyLLºylÎ›Ç`<ÇzzÃ1ôÂ±>oÃÀxòXOé±y;ôhGÍ®ð½±e%üå;(`à5÷¿ÿùõñËßþŸ¿þöøå{üDñû¿˜Á 6ð˜ï$@C©V%ÅÄçûÏÇ?ÿô×?_Ö×ÿ¥´Œy†(¼Gâ?¼ÑFš€D˜J%„S$–0„æZMí*qR•_ÏÅNU6Ää89û¿KòN‘wP¥Ø³\åPV_?@±L2(/Ã}˜É='“Û1à£x%g'Él’Ì£dþKRz>é¼‚à»!Kµ8º}Gð†Ð¸ÓR[¨+°Gg\ßÔø$t}ÛºÞÖTãÀÞ`ÕPÕ¢ÛW+Yè@V!•YðyO"Â¾ÃÀrÃþˆÊÖà,ò)Þ6mµ7¼5´#+¡n-!GlYâ&m¶CUSy!éq‡ogIôtè?9Ë;5Ý/{Nðv‘ë>Rïã3KQÊgäóÿ##Íæò•ŽÔI¤®ÝÂõ>P0'–ÕVKª*–ÃoŒ±œŠÖ<pMcØÂTÍZËH¥q™¨R-Î[>â9nsƒ¼Ô©.¾’e‘,_H~ ;5­ö
+endstreamendobj196 0 obj<</Intent 197 0 R/Name(Layer 1)/Type/OCG/Usage 198 0 R>>endobj197 0 obj[/View/Design]endobj198 0 obj<</CreatorInfo<</Creator(Adobe Illustrator 23.0)/Subtype/Artwork>>>>endobj199 0 obj<</BaseEncoding/WinAnsiEncoding/Differences[31/fi]/Type/Encoding>>endobj200 0 obj<</Ascent 1079/CapHeight 667/CharSet(/fi/space/numbersign/percent/ampersand/parenleft/parenright/comma/hyphen/period/slash/zero/one/two/three/four/five/six/seven/eight/nine/colon/equal/at/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z/\quoteright/quotedblleft/quotedblright/endash)/Descent -325/Flags 32/FontBBox[-356 -325 1136 1079]/FontFamily(Proxima Nova)/FontFile3 201 0 R/FontName/FCPYER+ProximaNova-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 76/Type/FontDescriptor/XHeight 483>>endobj201 0 obj<</Filter/FlateDecode/Length 4960/Subtype/Type1C>>stream
+H‰dUPWíùt40M™ÁT6jD‚DQ@Ðäç!‡pDP“Uü$îvË¨IULIÐå/•ADù¹˜AA"8NíÉ€FüEYo“K6Ûh¬JUº«ººû{ÞyïÜÓ-"¤bB$)#ÂbÃWÎŒ5älÏÐ§Fçä§ÎZ©Kß–•jžÊ+EüD)ïéÈ"7=¥¹¿ô’àãÑ.ëÚîé-'Ä"QÐ²°œÜ†ŒôMy^ë¦k×ÍðŠJ5dz­ÊÐçdoÍÉöñš;gŽÿl¯¬,¯— ­^ÝV!_—6Û7bÕê¹:¯@¯4ÝF‚	'!%JJ8ÑG“D¨‘Az‚È!ˆB8âé„71(ùŠîˆÝÄÑâ¿‹[Åâ%RÉ*É6I‹Ô[ºVZNÊI_²‰ò¤VRÙBYÌl7ÕNkwÀ®Ò^fïkjŸmÔþ”ý£	®tÊ\š®;Ú;ú9«ÍŽ¼Ó:§§çt(}”îwvÎs®p~âÂ¹ø¹»˜\í\µ®-®äKä;ägäß0³†9Î˜Ü<Ý>tûÜí‘Æ¯zôDµèfOJnú±ð|Ô†Ï)0ëÙ_O qô„ŒÆ¯éc¥ù î„¤ÐˆŽóÍØç~™ê5	$õE'‰êkH"ADí ½¨Ë !£©Ô(P2êõÃûkI (5&	¨ñä©hT“W^1I(dÇÇ`Ÿ@GÃ¼Ým;ó¡¤½¦¶·ï)×tCrw¹	RLÌùÎþ0;ûjøŽ¹Ðù°o`ä¾Ú<S%¼÷Ñ„ÍR1ùÆ³)~ñ¨/¹š0ø9ÎaW¤&ÆÄnhëé3¶šº›ÞUsBÁm{Iôà‰Ï8GÝÇ±1¯°Ý/±tÿî+ÙùüÿLò†Á£VX2Àù³]•=Ç;#+'îÞ¸5&}õ–ª-U¹5ÛÊ²k·œ²j¾ÝüD1¤9ïÏ1­>¡ê¹ëJªTŒ185<~ª]F¢€ì©»ÐÊ1y¹å†/wØýD1Æ¤s©iF;¦+x{©©±£¹nË»êèMKÓ¹¼ÆõŠ¦±L–1†G¶ØúÏ»êTåºªôŠÌ’¼Ýi­P§Ó­ËY­¤ùþŸ‹
+ä@_dÖßçãÙ–Ú†K—­úŠÍú<C6Ç”ê¿Ì¯<x¨¸øÜÌlmf¾VLúÅNÔü­¢0‰=WOF‚\2RÀ;@õÃ%×‘~è’€~è¯@ÿvœ{¹×•@¥4`1H‹2Ê¹s›ÈïÁ¹æ‚¿üÀo¸pÉäUd‘ÂwôG?/Èÿ]%2,SúJç}åï:×ÿAçæì´—:Ë@×'ª†ý’jÐ±°¿÷Sô‹ºA,é>ÇêËÕÕeeÕÕ†2½Þ`Ðúª
+F×ŠŠ UR 5Q°gt-KÑ»-üi‹¨}F†%íp›ÅùfŒ„HÐÜ.ó! Ô¨ÁÈ0Tc Ç/rGõÈ!ƒÌzàÀ<ÎÂ$`€9‹“ÐC˜ä¯¥ùü¾X] ‚›"Üm£¾¡Â"qI[Â Iú‹"_nñ‡%ÝùdÞ¢ ¦	d.à© ${P2ëmÝò®=žl;s¥î–²`ã|”¡;Jp?Æ©èv[à€ò,r~–-ì[f¤ê1c´%©„iwAòbvGôAó´ç³Á@Î¸ŠnÞÁÉqI\ËZ²³õbååà5mHðÒÍ¹YEÅ…ªÅ²âOkŠ*•ÌÈãk›ƒc“ÞZ¸¬¡#MEëE7à©u¼žÙ+<s·Á¢û7fñ‹¢ðÌX2f„_ Å§¸KFÔ5ša‰EtÇ§m’¾¬ºÍ¼a\œâ§!ð„Ioþ%ËWædfªà¸ióÁ1Ùå|²ù\[‰Iy¯gÕ¼ QsÄìJQÑ%Ûi3¬<²uHðh˜EõuvíÍïžL™qýCâÞËæ>>RtøˆÞ0ÁÀœÉÑÖqMWÈóâjý•€¨Vñ3‘e#ƒ½Ñ.å™mg:ÕkìSÞ¾öÞ½RpïžETÃ'IÀÉý
+Êùä¥±¤@}äe«È;la68;2ÄÜí€E,R/–ÃDa>âw_,ã«õ¸¹í;8¢C'Š×ìãÑqÞõDë6Ž¹hX=WÁXy7°²ASs7ìç´‡¦T*ú{ƒ·®nˆ0Ÿâ56,4eA`h³ùÈNrÆ€Úø¶‚.)´À
+3=Û:V›d¨ŸMjú*sX	1CËA³0ÿ2Ï[h™)?.ÇaËW-Uªâ½E{÷*PJTFh+38¸lì&V­ô_Öò¸§ý¦°ŸÍÞ‡TãQ‚Ú×qâ—ý9Oc
+éŸ3
+é0¹STÅGIªøé,Õ9EáÇR>ªC¸¡!=¼è.øw×û0¹N^_÷ìúoÄÓBâ7B]H€o3TXc1”8	4ó‰Æ+ÜŽr2cMô¶¥JB'áÛâ1‹a‰‚«\DJÚ–ücuŸ)þDu	þE.£˜'…»¢È³ÛSê5Jœ€ö(EÕ[Ýê‘^ÓéÖzUñ‡dê?O¦u)‡î~~†r˜"DK˜Ó0#0KÅ'ïbS³’"”‘ºó½*ï¡õÁSíú¬Ï8ú¶‹é^frqdÔM°ó¢Ð/x\øßxSXú«/ùe‚é$|O1#¸ˆcÁ{LFbE_*ú?¡ÕÕu…K†{¯‘zÍâ:“”kïÁ4øÀ`\cP#>yˆ<¢U2#>#š cjW£±¦ÑjŒ5ßõˆAå%(ÃŒ<”HPL‚¡Ê>tOÖê¾ƒØÆÕµúgî™{ÏÙçûöùö·Þ³Ã
+»gC3\my½EzØ`€2Äëu=Mu“?W%V±«´ô[¯®Éµ8@Á"¾sõ°æŽ3oÎ™m^`Rq>–éá=X$HoåÆÌž¼`ákªøOÒh•J‹ŽÉézÔTz£TœÃE-žjž £7ê€##¸ƒwãµ·¢O«µ9œcÞø2$ñhÄDLz9!»Úcwkhf¾-:‚¹–3ÈàQ‰2ø¢YÅµ|³ó®ží_Æ·á ôAï@zŒUÅû¹RZÎÂíØC »ìØEtzìÎp^L¥T–ýgN3”ýò;¼ø¡,vH²^×˜±iÍ}Fm†@T	‡[[ÞµJ>ÂªIð*,_n	•qqåŸpÖt}qL®Zý5W1¾Ê…däfâh$ åäYV¦W³Žh®‚gœ^p&äç f(g^¼ˆtæ½AÖÇ(i/Pº"«¯iÖ}^¥É+K¹.ƒÇ÷WÁWeI!ÎÅBHlÔøHËñÌUŠxìÉj–jèæñtÃq¨å¼y,ÀN:];¥578qeýîãØoíx™Ý¥Ý`=ÙS1¸“äèûÍÒùÞ¡ôàÑâÜŠf¶•Ê¢ð$ÇbÒœÅÜ)¬¬˜nSCû·gBoh"Îƒ¼s;È¥5,“6ˆé—û°¥/ÉñÔ‘†CÄƒ§ßx¤'ÆcÒ{ŒWXƒFÐaûcÀKdÆA0ò>ÝÀ¿ìg¤"~AÉÝg‡mÚéBE‹ë€÷Á,^¨¿nàfº‡^*fðLÆzSLìÃ`„ñcMêSz¦§1ôc¼V±ïÄåÊT[ÑÌ«œ­òdK§~‹õÿØ¤Ôé–ùjàƒÈ„û>\ê’ÄôYÌÒ ÖÁö~¨ÌbèäqâÚ¶ßª†_{ÁàÑ(*Zyk$~ÃCh ç¹@ozwß¥¢¼*[t§ÐÏºt{!aZõ`ÄçN¡Û1uì‰ûk¼.—mª«}gn‘RTÁ•GO8å+ãóþ&êÏƒÇÛ=Éjë»7SC½âÏ@À°¼Â…Š¸©¯IÁFº_l44³»°Ôîüt,¡Ò'H:e‘´;õÒf„po{¯*lDˆ3@@1|"ÆÁáõ *, D[6·MÑÔár²Õðw’'hNö/ecª³SYýáÊfÐrÍÜÝ{_ZÍnîòE3ƒ´™~Îd%ÜTi8œ†Aô™¼fù±LNlêáÎ^AÇ²]<î„vøê¹a<ã~L€ý4„MØ€»ð>÷€‡eÍ‰û–Á!b|ˆô“ÉÃLÏðhÆËä—i{œzNÜÕgWl®ÀÀÖÙž<ó`Ü5gê$æ!8=œœøûô‹iið·‹0¸Ê³ ¶:¤ulÁ·yxvlžï„Ykbb•ÌX.ïl~†M®-Nš®ŽÎ[æf„ËãGÇá¯T©ðwßÍ½UuéÀ¹3J¾»yUœuž<%á\Eeá¹Ú’Vó1Uü4½fY3Õ€Éêép@Iƒ´ÎapðRá7BBVùÒ«2xÞi§Æóò+]è¹bžE…&Áá<©‡d!÷pyV¹Üi5#'øGDœÊ]£ŠÓkØ³5nùº|Ø GŸ||Z‹³
+²•ø<nÑŠ·¬ñ²ÏŒ¦žž+ÝE_¯]xB-Êã
+’b³‚eô	 EyÿV~”hÔ_38zƒL¸ƒ/±Dœ ^)ûáËÄGÝžWË3³”r÷ÄÕ‘ËæÈ‘==¶¦ŽØ–$QÅ?¥WBè%Sé–ßµö>`#º}¨µT.(P–r–ÅÑ©seï7Ú>R™ü%¾c€'sVüC£ë!ZÏ¼ö‰Šµ¼}Ë…ïºesIãcªá…J·v‡®Ýà`c:«ý³ùŠ#§
+÷îÞøçÊ—¥ÜÎµk¶&Ëã¢£üÔ¤Ðð&Aü+ÆUÂjæ^“îbWì:ìøœ>º¬ôý[2÷"­J7Ù2“ u¼.”X"ûøŽÀ y'P#›Mwƒ©Â‹&KèÔ7÷˜¨³>qMd’Æ½áQ­ÞÅý°*Z3'ÒÎw«CÇ†‘„~àÎ+özx¢™nWÛL?9à‘s¬4Ë&W{‡"vÑ2«õÕ³òA°Cz î¬BôÀ£GS¾J^’šœ| åˆ*}Ÿä¬Ð;˜ÕDm§ãªØ¿þÿ’Ó¯êMÎ#üì•)Ó?ødËzeýLnÃž½›2ä¶ï«b¤kgX¤Ö±á†vWÀ^XÉTÛ¸wpl–±"45r.¤ZÕÑd‡K!TÿtqNwIz¥ÞvH7{5Ú?ñóƒ§L_°pµRôAâ™Iòäéq+­$¢Z“Óê¤›ZgÊ—[f«xÓ=ÂéC%YEråz!¦ýWä-ê_¾öeóÂ°0W6¥óCÕk¡Ž–R}T]MÝÜ_`oÔAÝzüîQã7‚1ˆn‡~è¤	÷LH­q÷‰lý±ÓÖÚÝ]ì?<*ØG%ÝŒK“¥oÿâF©p¦v19¶•Õ2H­0F·£ôÆœ¥	KIEßP®HFl ›¨7F†DDdå®Q`•V¼™år‡m‚ñ©Ð%É6RhJ\¦Â0¡piDæ}*…#[ýAª²¿˜£âjÝIzK4éQYÛIzK5éáÊÖ8ûz­”íò•kp_Èùêòé<yçgÙô™Z/„G'ÅYT)»Á$ˆÆô
+¦¯pË«ƒ´:ÝÉ+úØÂšwÿMvÙ†4…q¼1ï½¦óFÞ®Œ]Ø¤/Bú¤ÆÃìCø’†ÙÈ§`[¾ôâi4ÑpKÅnSZ#mî:I{·0§%•µ‰ˆEJ	A&Aõ9ëåÜ¡aôíó?pž·ßsž·lßýØÑ³Ë­Ëé:ÜõPsïŽš;UæÓÞP·JõëÌde§'}ªž¯ÑëžÖækŽM{3sýCf²ìö[§àWHñqV	G­ü}¯óŠ[Wý„ªo°\SÝõAŒ‘¾u:V“ÅÓÌ¾Áâ-+F(dYOvœl¹Ö¹aLIeÞ‰ƒBVQï{Ì¤ã%fû˜áëë7ïiY½m13r±ÕAU”0OC!²Pzyü$‡q
+J¤v“BMµ}Ù#"õgòUr¬¸Ô@‚;‰4æœ8&ÌcŽLlsÄŒ!f9[(Ê2ˆGjŠM‰´‹ÂŒJ¤NX¤q.ØÉ¼·RÉ4ÖàòÉ!&Ù¬ø ¶SÙÀ@±z\0U"®&¯½ñŽã­û)n¨ÙÕ{©[xiñú^Az£ÖÓ^ÇÃçÍ”±¶ºÞ$pUÖs­íõ:6É„•"€¢”Ä½4xà'ÙH7e‚›ÁnŒIŸf¡#ß€µ(ÆÇ¿+AXÕó…¦²¼\ÁW5 ]ëñIO¥¶©±¥Ehõûnû=Ñ°EÚ(é!q]Òæï“%lvÀ6B™ÉøåYÈÑ3º,—Ú1Ã32ÝÎ¦ÆN­{â_3ÜA2 éTEØFsHÊÖ¥!…„$¥¥<’Ba‰–]š^Q +;´„òùƒÏ5#å^SùÙÓåWÅ¾ö»ý²¶Ù\a4‹Ñ`8Éÿ•Tœ!Ø×¶&©”%ì'²8;V:!ª›Æb·ËÁh=©).×oÕf›*Ö3ë÷¶µ«Tsª8¨Ý†¦ù? ’®f
+endstreamendobj202 0 obj<</BaseEncoding/WinAnsiEncoding/Differences[31/fi]/Type/Encoding>>endobj203 0 obj<</Ascent 1079/CapHeight 667/CharSet(/fi/space/period/zero/one/two/three/four/five/six/seven/eight/nine/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z)/Descent -355/Flags 32/FontBBox[-373 -355 1170 1079]/FontFamily(Proxima Nova Semibold)/FontFile3 204 0 R/FontName/FCPYER+ProximaNova-Semibold/FontStretch/Normal/FontWeight 600/ItalicAngle 0/StemV 104/Type/FontDescriptor/XHeight 483>>endobj204 0 obj<</Filter/FlateDecode/Length 3931/Subtype/Type1C>>stream
+H‰lUmTçÞa™Y–Yug]°ø¢‚ˆ$)b”E‘Õ]W„H…j{¢?lÎI€œjÚ˜h“øq5¢PQTTPbÀ•5j1Ä
+™µç½kOß…˜6Içý1gÞ÷Î½Ï½÷¹ÏKÉ\]dEùÅÇ¦d.Y9+ekáoóLÉ…%¦9©–‚üõ…›ÍÎóé’–’ü\¥©*Î¡DðsÝû¯Â½`™7$Lhö›€>29EEÆb‹¶oÍÏÍû.ëW²‚tI¦­V]j~Aá–âÂ-³uóæÎÖEoÞ¬3*Ömµ[¶–XÌÁÎp1$\H|jÚö"‹.Bg¶l”É(²d^2Ù¥lÚYÌYŒ<1µL/›!‹—í“—!•O}N½p1ºl—Ëå¹òJWÚu¥ëG®®½t½ÞNWÑ=ô3—12'™aÅE•››[€[Ž[¹›Mé©\¬ÌQ¶ºOr_ã^í!÷ˆö8íñj²Ê¤Ú«:¢ú·g„çï={Ø6‡m`¿÷šéµÊë¯^ïÞ‰ÞMa¡ÇG§lÕPW#·…r`}ˆvîp¯cÝèa‹wY|²tTèä-×9Kµ¶¶¦¦¶ÖZc±X­ž=½Ó.m³SuàMà!¯ƒÇFõá0€¡–@D-†84 a1Æa/Í÷Eµ¤2jPŸ( Î jžEãÁ’ÑR
+Ò@)‡4_PŽ†0˜†«:ãˆM³ÊDi“’‚I¼‹¾R©ˆM,-qã^˜‚t7rÁsrãRøÎ7éÆú¶š{Úö6ë’Ypfì{;í!Âr»¤¥?¸©Žq††¿ÁCÁÏï-†^Z¾GPtíû¦¥_®3;QòÈlCßC76¶Vvjï¶Y“’SŠÞxÇ\V¾S˜¦(ÿó™²*­zàÙ¥ÂeIæÇÅU_ÌØòƒ%0K„ö—e¥>ð”êxAÒ‚Yýâ<)Ã<êˆ¤ç€M¡B\±×)Øƒâ®ÐŠT1ý Üå­ßq	—{Í ÐBÐË' €_`/º&¤½cµ
+Ý¢c™C©xXLŸ­¿ðÙUíƒ–¬Øå«V/üµ¡ª9[`;‡!ÐÙ*w¨%þêà‡I½82 èù0xÃ4}7ª¢–³øö”íÙ«åW"È;j·m<Å_é§Ïe'Ðbz ÎÆtAšÞ\úÚ¤ùzó·wvó'¯T_Õvwl\$°YK¤v‘:*m“ƒ§/Ld`Ÿô¾ïØ¦‡
+öÀe|êÁ]G ì”»º¿ÞâP‰0üÀ£<Å·GåÕ=w|ÕôH^8±•è>«Ñ+¼cÍÝb^ÝYŸ®Q÷H>p‹K/^¿›_¿7ìÈMMëåÝ¶+›R‰ÍÇØÌ­HÌ~+éËk]CÕõäëÞÚ¯aí²CÀì´Sµ„¿§IQþv“ËnèØò@é#0›p09
+æcÍD/œfÕ½ÛMÕB©©4tAÏDó¡/óxè€Ï9ã¦Ô‚•ÚØ„Ó.¿ùD<»G`I÷'Šðôé~ùè<‚ô¬³"¸4„Æ@ò~B“ï&˜HC£ÀyR"ð)2lW™I"D‹>6Bƒ“ ÒJýÒæO˜ÐÕ#>Xa‹ûXPK7>¹Üú­fpé7ÈòxŸ%ã Š¶“33ósÁ:’ M¡~ùõ)Sæ
+K^‚ÀŠ¤%NN¨ä’ïNtn÷53šéTkÂú7µ¨èþ1êžSZ0ÜL÷eFÜF–ŒäÔ¡	M@Þ&°0‰L¦I¤œPÄ#YÎ€üIG3 ýG³€dOéhç$LR@P_ rè³p:ìû¯³uº ¿KkE ˜‹ø˜d3 :Ö2ìRÐºÿ1"Áê~jü»vˆaóXbÒdb6¦KÅ©dTÜ»oñð!véÁ8]QX`°.Õâä ïHuòÝ›æÌSÂÐeº'=üúÊc(ú¡…¤¨'ÑÏ‰PY:–å0q-ÕŒiaf%C%*_…“s0Ì°Ø=®e¯:­6ˆÔü¸ód÷£k\æ…öÒ.-pC6˜-HY¨t¬QÄdc3r+ñlý]H›|AÏà9x	G “F"‹Ÿ¢Û1ó×:i6‰4¡ýuL)DÄR»3,ü‰Le„’3i¢†Qí8ªE.w¤ã2)ÆEN_ái…rôELRÍ‚ÿHà¹Í	_ 9
+”
+hT9ÿ”vPÉ?ÒJJ&D«¾ü1²Èò‡@0‚‘ð!³È"ûhä¥ë¾8uÁtÔ 6ÌNÃ?‰¦kžè‘çÙc¤ì"ä“ëè8¹”Pq½CDúé7†P'àyFÒ¢…K0š–ñ¸ ò`s«ÑD˜þsL£¹ÔÏA¼yóê§•üµå÷;ÓnÐ­í'ipÿÀýZÊïVmY/DD¾ýpýn¡uwž–múX)Ã´.„ýtß'÷ˆ´5{Œ“y<?Ö¹
+pc`ü?ÜûÇ/Ø&PÁ!ráUr‰×ûsÀKoß{rÀI'Ñ¥Jˆúbé_Z4Ïèºm+^ÝÂý„nKZxbºg†¡ò‡‰V Š„û%¶íÍ:KÖ¬àØ¿6­åÙ÷ÇÅv8ïÛ¤ªR;d‹ŽÏôM:©'«(õ ÑGà0âÊa¤?#÷m$Oîw‡^áŸrtMéú'/éÑ]Á–ÚßÉ˜1Ù+‚¾ÈÀ˜ìMùãÕUÅÞ{Ç¤§øšY–wö=E­ÃˆB&:º%¥2.?Cê¬4€$DÆŠ,XP¨5H‹À¿¦‰F~¨ ¨È±$t•bC˜aµH&ïc¿³µ÷´§öì{ÎÌ9ß÷æ{ïÜ{¿Ÿû¹Ÿ/Í™É6'~%³üÄÂP’ˆ§k÷»ÿd¹4é†<h—wÿVÞ­r–A*¡–ÓDÀ¥—øèdöÄ*)‡boÏ ôÐ´F)•©Á›&á°†(ò(M‚I>	|ŠxÓ`$7È!2Aá*e{~Vt˜ä"˜dhÕÐP"yQÄ[ƒXHXä5”:½(öýžk–ò”Íj)ï>™¤Á.%QÎ7ƒ!vgÅ¾lü|S/¬ýü»;-?@ªƒË‚ŸÔø‚µ¶ÅûégÒ#tÂ©uTÓ_OÔÅ÷[“tâz¦)QWñ<ÿ”QŠ\›÷hÄÍKg+›…ónÉ»¶íã7Ç×Ÿél®ï±¶ìM®ÙƒFÛ¦Li‰B¯: æpYWÕšk»ÂÄš»Súx˜?f‡ X±òYð¢ngT‚EÆáüP:¦±òLMÿUg¨VñÜê˜È“"»Æhƒë6ˆ
+å§ð¶Š,½ïKíç>³Ö.Q¯¦½jx‰ØÒo·Ÿ¿òÍióž„âÀ%Êšþ™–'K{“%¿ý@æ.ùªÓ~RDwl×ÜÄ•‘˜$	ÓÂ‚‹gkZÍÂM7ý®¨Ñ|`D¿ÍÞÙ?ÜÞ‘ªÇ4wGàw×á‘9*8öýL`Z˜³|†®UY[…Ø*)I·ç%~ÅÖÞ/rEiî1|—ƒ’øE>¨+½È‡ Õ„åáErŒî)n¸Ã³¤
+±ÏÃœ$E›ƒ³ÙÔ‰¿7þØ	ºëø‰¦òò¼·JQTQœ­43å½dÞãf2GLòûÃ’¨PØ ÏfœÉÓäàî^”EQÏ…×QAÌÕiX'r·¤m†»ÊtlßzòEž,XéGV`Úþ0¿¯»¶Õ,na–­Ý±acô‘–íªèWTúŒÈÔ¬ÂE›­óâpÛ™T}¥ÈæTÌÖTGîPJ"¢i‚þ6²kQpØŸvà@ÓüËÏw˜ºcÖÚN¾Ç’"²hd0|gXØj2×ÁM"ûõª««S«õ‰)©z}MjƒÈÙ"½*‡dÐàÐŠ•þþÿ˜t©4Î¿Ðá)»ÞÜ_x0WÈy‚Ê+?’ÿ1ÿC×åû"áúoxYX)yªÁ“F­pâ`'EÔ4I"Ù”´Ê³šé Ø™ÄÍW]XAZxÏ•³Ñ…nüánM/Ã´¿§ïE·ú¯ß¸-~§Ð¹/¾q=¿nclŠátEã48î–¡öãSuVþ\eb¤HÐ~Œù¤¢¹î4V~Ááù5N;ÝÚ°šg¿ W“k™u5$W´ÊZÛÅ÷|šŽ=ðŸZl° lò³ƒŠ\ÐCüˆÖ—0D âa@+ÚÜü£G¾n½Óòäªè•x% «3!Dö3	Ü]XKPù1‘–î´<xŒN`çøÛ‰G˜.%V@º‚ÅB$I
+éi•6"40&²¦!C˜éäê6~¸3tùùþ–ÒaôÅó“‘øÓª×Õ„aúkI 	õÝ'ÎXDRÄÀ°[bFdŠ¿~»›p~$+öûÉ9^Îìb™¸ÍÔWôÔ4ó¦’?ç§˜°-ú8Ô|MÃ°ÞÆa°}¥hšÝ¤òxŸ*¦}ð5ì
+õµË_½¸jõQ1Ük2{Õ7|ÔÝÛ•ž\-4_§,ñ/T¯á	ûì³O‘9ßî~]ìÙß‘õŠ—~GFXXh]C^Mx }ãŠQ‡’Œª¶OLG?ÓoRoæîÉ5ð)ûªêDx{<5Ä•Ô2A§âo	¬ÑEK†Ÿ||ä2â¹2Î$§Ç¥Dð›*E8§!Ì²Ž?N}Ùk¶4lp<¼Ôe™/á$‹DáCC´d %Ï¦GÉ8^¤ˆBv}xe&< ’Jñt%e«á74<.(hÎäC¦S”8™òÁ¾†Ç¼ÀÒ\"¸ÁŠtu¢XÚ«”æªá!šl€B#EpM“@t(¯!ˆÉ3¤BÕaÅ“(Ûó™ÓOÌÆÛç«Ú§¥8ó;åÕyåü`áùãu·![ê÷Äè;Ä8³wm¥vdï~#™çÒŒ{çˆìâ‚1èWX%NiUKÜÉ§á ªÏ!ç|?ÈeH.¹L±).-@ÖhA"…53ÔÑ!…ü/ê ßÈdCsÃÈµ×tËÈt{´ì·Þ*oP¿¦Z†F¶…F'/Û´ã‰1ì~“d(í.u”€Û4Éü ¬”*ž\UVö“ûÜ÷y=˜×ÐR|ØÝýA‰ûÃpàéKÕ¿ <U9•
+endstreamendobj205 0 obj[207 0 R]endobj206 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj207 0 obj<</BaseFont/VSSPHH+ProximaNova-Bold/CIDSystemInfo 208 0 R/DW 1000/FontDescriptor 209 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj208 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj209 0 obj<</Ascent 1079/CIDSet 210 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 211 0 R/FontName/VSSPHH+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj210 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj211 0 obj<</Filter/FlateDecode/Length 1408/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»*ƒ3[º*dÑñÑ(ˆQ JQAde-]yì‚¯%V­)ÑèQÄP­¢«…–Rµ´¦±%Ö–J¬Š64Zïà]ÓÎÖ¤úý»ß½9÷œ{n.I¨|’$'$'&.‰	^^h+µægÄÛÓÚò2½¹0Y*4¢<‰”µ*YÔè<:*@uæu êÒB²/ìôƒ­šÉtƒÆHÐ$©f—$eFeÚÌ–ØLKA±µ¸,Úf/+´fçRƒ6¤N3,Ë(Ì5$ZómE¶‚ÃÌ°°ðPCT^žáß¢"C¡¥ÈRè°d†š'&•Ù-†Y†LKÖÿø)"Æ¡%ôD,G$k‰tb=a!rˆ\ÂNl$
+	‡ª“"Ho­–Ð*z‰ÉDQDTwÉñd(™Fî!_û$ù´ú<£Hj!u”z¨2ª
+T{rfÔÖÕ“7 ¹‘’ÃgèFðÅ›nÕë°y´šÕ,fÿt'ÇG6ªa2Õƒ:Œü£ !
+"!2"1#0#E9X¾ÙÁ!ÁÙÃà¾çž?=‚¾"k¨qŒšœ$¬ƒ(x®5á8³0û^ø M{Jö~øÉó•n²Œ”Ü®?l``	pOþ µ?LDú.†Y#ãÄ{Óé‹mWêû…ïºVÌ™·Obš„*†½Sã ü ¸
+'Ï ¿-oÒƒ8~ár¦0xÔN£
+n¡È@µ
+cÔücˆšÅÝoIÞ€@
+2½ß˜6×;….…{ƒò¿¿[—ÚÑ[vS€IÏ‚™’œ„ž&Îœ±4ÍZwb£ÈÂÜ
+Å‰^$n×h,o—£õp`ÔDc„šwãRÏ\&ðFPùÆD³'\ƒQ?ƒñÁÐ®´°x~‹\¬‡ëHSZÑgÁ‚¢UËÅŽú|sÇ±o„¾–Ü5Rs!7áøGÂü03Òß‰Ä£U·{/×]8#òÅ«¾ÞQÙ¶š…Õæ“míÍ_v5µÕV#±7]@O& !Ò©ô[@«ô;îU«ÅÏ™NËÊ	ú†ãL/pøï&`¯tŸ¼x^ä·Ä{‘ÃT¹%ëŠ×Ñ«/<èº|ëë¶âÜZ‰=ëÕà«/(Ž‡‰P¾üËFØ¥CPA0µ¿¿¶­SL¼Oçç%—­øgsÖ\ºö©xJ3§F‘‰SH£A‚½¢{ÐŸ¶WÂíêŽýMWïlCv:9¹.AIÓˆâË%]KSSK‹µ)ÃœcÍÈ8km–øÇ}žK:Ù‰¼ÇÉ°o-íž‚¯HÞké5Š™4§$`­‚Õ&ÒÃæIÊ÷ï¸Ü’•'ò·{½ À3|üÂœ®¹pªKøölqŒ„mkv=‡ëÏH·²ä³¥jzu©—îÙàßc4HÕÎ®–VVZ*ëýOÕi¿ÚS˜wZìú>ŸwjŽ€ü¢Es‘yåØ,õ”·¸¬þùK“>Ž>s&Gd1FñÈäµ@qsìPâÒu7U9&ñnû0½cGÙŽRÁ¶¹®^‚‚ç@Mƒ	Šsæ!u÷1¼=¼#mHd¯ýk´Ì9ÿSXª(ôEÑƒw[I¦}°2§ö	Ú‘Çafz×Š¿î\9çVV¨4žawa
+ÐŽÑYNn§\ËÛÛq…ŽwVÝ¸û°0°§ï‹sÀ)_€“ÔÈár0Dc€R<ÛÊÌôFWÉöO×¦½ûÊ%å”Cy"¨‹?êÒÝY­­nwkk–;==++]d½—xŒ,i¦tÐmÜ¶C²ó`ÏÁ—• ªV££ºê #ÖD„WUý­y·B3Ö=ôcÝ=ûŽh4 ¯Ò¼ûµòaÝ? Aý¸6
+endstreamendobj212 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj213 0 obj<</AIS false/BM/Normal/CA 1.0/OP true/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op true>>endobj214 0 obj<</Filter/FlateDecode/Length 17895>>stream
+H‰lWK®¹Ü÷)ê]"“ÿ­eÀ+Ã0¼ðì™Ek€ßpDF’ý$èUv±ÈüEdðË?¾^_þþ5]ùë×ë‘î•ç…ÿ[¹òõÇ//ûWº~ùßÃf½Öõ´Ñ®¶Úmóúã?ÿ>~¤«çB{¶uO,	¯ÿ}ý†óèØ°µ¡ä+á_¾zºkÁÊÖÊ]rµëãÛƒo¾=ìî³àéõ(wùz¦;•u•»šÑÈ«Âè­Ñ¨}\X¸z§9Æ¼êñœï‚åz6¸1±Lv-åŠOÊÝ|ï¾
+™³oWñªÞir]®‹†qÙ=÷ã¼Ç×ãWëNkÁÿøBæ‡¦Z·YïU°Å¼WB*ïÁ æÝàÖÇ£Ã£™m\aÂ£qwD1êpë&"Ë´Î{LlØî†ßp†û=°ùÇcÝ…ÙCP(ÌÂÏÄBöŽ‘}™ù¶Ê7E/þMÂ¦È±M?o°
+GL¬E‡Üù‡yéøøã1P°”8Ð±Ÿ'íˆÜhÖ`LÖ¥w9™“Ùó%Ïôüñx²Éö«×6Ÿ¹ùÉ/¦û<ÿŠNüç§Î„Î*H0þžÆzZ¾S«ÞZO3”|XÙædöÃÊp›Ao;þ¼Þ?URÛ¢×Þ_DO¯~GŽeiëø>íùñ©ÿ_aÉ1íüÝêˆ'éÏ·óÊHð¾Þ?`ëAè6lf»ÅŸpeZûÜñþ³þ°ggÛD:ûÚ…¡c>2ã¬×6[E{ºàÖNaÐ?Ð]ù?œø|§¢ýðzw`‘*pF~ì®©Æ9AN»!òšømÚª·ô'®!°ÅÛÞõìêÌº& ¯ÂèÍý30æÁí®kÐ˜… žd©I#UÏÿg,£±7€Ò¾V˜hïŽÏ‘aÂº:Ê$ÖA €Ã!£R:Î»²9LÛ¹5@Á^üŒˆàÕ6H¨%v—;?Ù„´É6×’3TN©WrÒÌË3$¨Ž»u'fcYaFîÀ/ðvgiÆ¶è3?„‘}áœÙ°.íàgÐÆžD§LM:‡Q«……àm'%ÖƒZ†Åºúûd ´ù€`º¢fÏ8 ,}µa/Ì§Fª¹ó¬?™Úð˜rÁ›)# ~ÏL™ŒT‡¡Û]*êÿ¹+ÈI¬Üb-oË–w°ë#yFÞ c¦rrl+6›:,ãž-
+Ýh8ºr´ÞÍ_ÍÁ9 VŒ†k÷ªœzÉT¾Üie¯liÞ¦2Ô³­­kÃQùª'B åü6¬O­ëµ²Ëö†¨/Ù
+d@þØ“ g4UFÑà2ü5MkœÀ^êBIf(wãèT­AsïB¿¢O¼¥Ùµ`fxL±Å,4+ã}ÊZ‡ÝKÏíä¾:èPh,Ï¢1I  DÔï±Lå©>%iFE`ä¹K@9Ð”&³á z-v€µŒ®C²Òâ"C“z‚às¢È¤ð Û\Á ;tÉúhäÍfÇ0M¾P¦ÝôÒ ¼åLTœ+ûÞ‘’'0*Ö	ŠÊÚäbvœ´w,Â(£$S˜EÑ;{<'ÇÔ]ëe©2[-¸Ú«>’S7ÑÃ w"ï§H™ª°T•†¤ú¤3B°hŒP{YÅ¬j’Âc²´–j¼éð|2¬i8ø† ÏÚ$B™Ô;o+ÈEÎÐQ;„*Ür÷áò2¥è$ßA}âãW`êv=xðf¢†û ‰/Ñ§$=ÐAØÍÞ6|¢i`U¼/•È…_de¼Æ¾\L\Ð¾È#°­»üá³nŠñ¯]17e²ý.2Kø³ÞÉ·È©8=‘D*’UÏB©>&Ìó=šK(SjÇš>*×›9ÃyF«¾¡;E’¥ÆMUã¡ÿ9sH\2>ò‡Ú÷b¦ ª*ºå]mìê§ÈÚƒ]ê£Zœ¯›Ú4ë&BÄF½³ÝÖ¶.ç¨?Û>-óžá=ÑþäP·ëTƒ?hªùÈÆÏÀõÑ1Ìðzûo+¼û ÛP‡îh¢ÉR4adÊmñ%³ú£VÏu¸Û*ŠYÒü.¯ÿÈdÚs\­>jWÁ¤BoÔž §im¼{šW¦¨#üÚ–°ç½T-`U$}«ÄÇP(u‰–úÆ¹¦èò}]#ªÿƒ‡0Äè›N‚Ù£§Eû§K	¬i[T2Ûf?çÏÍ’¾R¦ç‘íáÕaÃèEQ­FÉjÎ œæ^MP)Ø£™d:2Mß¤K
+‰ÕdÛØVRßÂ$³P*ÉÂ<*RÒ~†.òâØäŽ*Ë¡T74 ×§÷fò7ÓUÿÓ,¥‰R2d*†÷³¾4c¬ðØ•ãêÈ{HG˜’KËX»ö2¼å{ná–O›Sî!Øð	bÚý\ŠUÙor²HóîçÅ©NôF
+*èŸH?&Õõ/D/|¦¥îê¼¾ƒx|Õ ò8Ñ«‰´Bô¹z$ä†ñbí¥ÆÆÝý"ã3ŠŸ5#Äã.€ÂôõÁÔmIÃÑ(#T”¯Û)Aß=Ïí¥”º£—‚ÈE4dçŠ¡©	«¶²µ®{šf?Ãž¢2Ò³/œ¨%n=ÇEvÈJàí™¹åé¸Ûy‹´Ôz-©dÅÀÑu°ÅLö^¡j	y× -®…TIc²cgLô˜Ø1Âˆñ¦1Ì)–l¼½³šô#QlÛàÂ¥èç¢÷[Î6L—‚éDbHß½¶¹/|Á†2¨IWß!ü§±8Yc±’©[>Ñ·ÙÉMè36ÊÑDê^êïŸ#Ú˜Ö®ÚíÜ~ØEéÈªÝSJkX^P×4ñuímƒï)N\&5àª¥œ™C9âÑœ;ÐaãêÈ ft¢öòlŽ—Éþ~Ñ\I5)lè”™f¢;ŒW™!ÎõåÓÚð‚Óu »ùDá•¡äð·ûõËPl©»#Jài®‚vY¡7:éoÙ‘ƒÎ‘V>zMoxÌ—ô~L,©B‡g¾¸XšE.iœk²+«ñéë¡öƒG³\ ›l(ÏÚ$†=‹´Zñ'ht¡[|p#¢aÔÑ#3¤ñòI¢uÁ• HÞä°Ñˆ]9F5J¥G«óÌuÆ‡î@ª
+¹ÎXz—Îæ·Y†0$;´î´³öTN9*âdÇF{7Þ–-ä.§¡@ÓL×µ\¼
+ÜaE–k[¡šœÄ0ÌÓM‰ì5oâþ’é!¬„ä5ÉÝwjãÒ¢ºá“!nuäŸjëÊe«?‹³~“È‘‘>…	Fß¢!öðàu¯ÅÍT´!¿$u™Q›p
+RáärI|SÕ÷3T5¼%ú¬IJ„„^ÄF.´ ŸÜUN´jå#Ê&×æ}MÛÞ¢È;ªœ­„'—chÃ®Í(x·’´×ì‚OÀ;f:+¶…btCºLèf"¸&u	”‰h$W”4Üàš_uICŒ:!Í²uWLÕÿÌf•¸å
+ÿi?|¾Û¸½#µZ;~ƒ÷#ßï?’0ûÒCµ¡¡¸KvH&o ™Žò‹k˜ÃÔ¢e:—æ¶¶Ö‚â,±kx™ 6¯·ktìàD¯SHÀƒ¤HNñì‰N®=CÑ{¡ãb†êÊpBXh„º/³âÜ;©MÏ…ù¹"¿§4ßë!QöÜmXÛÿù®¶Ý:Ž#øÎ¯ØG*ð‘gfç
+"Çy Aø!Š:6™’
+/vì¯OUWï…¢”‰§ggg{úRUm[‰*BV‡5úKfæRy”;‰†à8ÛÆP„€ƒ%ãpˆñË£¡ªc /Æ,Âš4GTUÓXÖdÓŒC“bÆîY›«Å-R¶ô£p€˜|‰¢Úl=,ácÏX±>ËP½õ½ØÙ*ÃjZ:Fe"vÙ¬Ê2ˆÆbž63ÙtàæZ2u~'öªÕ7ø°47¨§o‚{ò.Úwô+”ã<RÆx!•¢—~ÈËpÇjo«x^5w!Õx_¥DÇ2OjÞµ6ë-­šÑium[Ï ka¶ªÙ–öi±Õ“§3× ;3£¼ch¬–:FUvwaNäÁÊÒèk××Ñ|TÔÈÈq ]È]ý9YÎ…Ýè 7Ÿ<Ä*Â3¡ ©ƒåbPyÐ0†ï^j7I%ó0õ2ù!Ô¢XC$Ã(%ó´˜TIœÓ±×’r´RÇÎöô¸Ô£Š,ëôá:t™cÄƒ?Xæ*ÙÈÛEdÀîáæ€óÍ!» n––»[/2¸“`S«ú½„Z–â¡Ý6'Ú1cùµVÉ'ÔÑðDh´OÄ«6ˆ¸¨e¦à,J§}Àk~<8ÂKG=vl3ÔåÆ$"s¯^‹á˜|‹”mË¹§3èWvD‚"A×‡¤×kýCwC© ýeò+ùü:/¨¤êÊ}ç}æô bªÜ03šJµ™|²¾_Š5L"p©‡OÃ
+4Q
+Ÿ×Põj~¡¡ò4Tü¼†Jã‹"*îDTÛ‰¨þBD•Ï‹¨úBDÍÿ_D±û
+è·«½GôþÒÓÒû!=n¾:%ZÙI´y'ÑÊ^¢åÏK´²“h,=‡EÝOØçø¹—^iS^¬î°–ù®ÌÞ”WÚ„OÛ/véNx•²^á¥òâê*½rÞ¤—›ôâ-WéÅÛoÒqÙK¯–vÒkìµWŸ÷Ú«Ìy§½rß´3°×^µnâ+‡ºS_mÞ«/ Ö¦¾Øh‹ú²!rS_$æújaìÔ—zÞÕ—°\êËâ¦¾ú¦¾8àîÕ—ô‘«¯šwêkìä—ÞÞä|Ýä×(/äW›üJóN}•y¯¾ZÙÔ×\vú«öú‹>­ú«Åþ%­úkC:/–E€Å0^°¬irS`êX~x³È;/»YÜñ×³w¬Æ&EM?ž}ýMøÀ¦‹Î ¨ˆÃ…„Û¦‹g¿P$!ÔBø—`¿ƒÝaÌ³ì?Â†Y±Þ¢ïÅßVµ'¢¤Þ}³û¸þ»‹UAÓÅø•ü{ÎSjð7³vÛßÊ7¾½8ûúâþùêúï¿¿8þ÷éÛ7OÓŸÿ¢{¥n*gýŸw»ˆ¼¯“ ÍÄK.æ1¨îáÁíÙ?Î/ÞDõü~º>ž>NW÷?¦ËÓiººy¸z¾}|º¼»:>~5ý|œÞüóâOæûÛBçÏ¯/:NŽ?O÷¦Ë;{ïçë›§ãôxóãÝåá\¿ø>òôüpÄ†uÓûÓ³ïá“7m:;}w}|ðØ;ïoÞŸìéWÓÓõqº¾¸ùõþîéò´½»¾pþx}ÿ|ú0½?NÏtçÑÞùøps{ùðËôþŸ_ºùp¼{ºyúeÂuŸµw½ú÷”ÿ9^çúÍýÝ[]úUí ¾QñMÁâ‹?¹C®P« 	Àâ{Ž:œþ¶^T©ü¢X#:­O½Œ·6Ê|8ž}7ÝñhûN/ÀtZ>§žE¬…š¹û‡×¾m”^Gï€9:p?/ Ç ç½àLR	MÖ4Þ,Ø,fƒ'’œ¥¾WLN‰HÍ@³‡htk&´áì¢<):ò	 Û‡ÍÚÌì9Ðè6m¨ˆd\±ÞôóªfñÀã·gþ’ÛDÚæÕ€y=€TŒ$•H,5BÁÁ ŸŸ¨!–±ì)DšTäÈ[LÎE`L£=`M¥	\çÛÃ<ÂnD¡ónÁ„1”7dÉ°A‰Ú8KzãÆþ ³Ø‰:½QÂ`Ò(çF NwdD²_´ðÃa:„É„K†³8
+‘ˆÁÂÓ-ï¤³„‹˜&ú9ŒàåæXÉ>Ø¨'û´Ú‡4àŸiÌÝïOeK¸Ñ Ç!d PÞ¦Ós0’b2*ið÷!g;0OQãb7!ã¶ÿ9m"Ô©s2(—º×?á&É‚?Ðc1u¾â†&3ÒÔÿ'·äŽ>7J´ð?·ëu@µÐ-ˆp¦wCƒúá _ú([{ø²þœ.*7‘
+`?i±ô!ãJÚþ¹Ój£”!®tP)FÑ:ÎXNø,'}a½¤ŽúäÎbÚ c™)§ÖÁÜ7s¦ð/\íê£Sa‚{bÂ,ôÝmìÑ†¬L^Ç^Ã©^)LR>5›-LwË w2Ë.ÉQ(‚¨Ñ\ªeû&z0âa#„£FfÙè35v ¸\CõÖ ÔdÍ) zà‘;	«q:›‹¶ši‰°ÑM[F½@¼‰Í"WêŸ[I–u-d^b™'IÔ„L}¶Ø¸¸kå¬YiJ”sn pªà€•° ®òÚypÞKØÎ€Øð—,¤5Ñ¬MòºJF±d7Øð±MJÑ  U«ZZ?0%˜—'‘²¯ÕÒ¶WO.-Ù¼›J~mëÈí±9Ç=<êá—àUGáè§¾óÌ)iWµ2vŠ$J…Áju^rS­V—:4BdJ2‰®x´®è4›‰†F–ŒP€gØÔà™:¶jo&ƒë#.ÅÉú+F‘&×‡Ø™b]aDÚ)êCÙJØÈiŽâŽb0
+ÓHµ¾¤PÛ˜Bµé"é¸jøP¿`rÁh'M`ð|$}gO¬9V³›žNÒtZR¶«>kÖÄ¯•j:¤G>JR!Ï6q0Ä:ƒ‰Îöi–*6¢PÃÙRÏãxËƒÅ«™|a‹›	9àÌDÊŒ’Yž`(‡Å½R²Ç|ðK½X ¹¥«A2O#Ì§–ÄS(Hvh­d=<Ûý9È\­=ÂÑU&DNº«ÅfÒÞ^cA ”þQ€¨›ì;ÓHÖœIÌ6Ã%áFn¬Åè™§ëŽÃº”Z×­82,h¨hÓ5]&Ø$‡hZ
+Ä­Ø­²ÕC‡¬ÁN¨nS¢å)èó³ÑÁ¼ñ„y¿Ô–R/•1Tü(Ó+4.¯ÌÎ:®)gWÀ¬‰ÇÅrg£ ›æ[Ù¼N±›°+9ËY;Bõ‚W¢º ØÛªž°šJ„7ÙDQë/BŽYäÞ•b³·ÐR<8¾©¬°U¾ô·ªe	º³F6 ±.÷ô:xc{%¯Y˜8:þ/i“e·µáÀŸz„UãÎÞ,$Š©e)÷™ÇõÙ°˜æ³U§˜ÅI,Ï¯$	_Â\kp#ŒòY o™ÑFìbB¶—¨„80±„Ú±VàkEZ´¢Í?ƒÍç=ˆ Œœ“§Ü*ÜLz"2Äy¼¶¡ñç\Lª<^-ˆQ©ÃÔªEX?ëú‚çƒ÷øªt<Âî>±°.ÅÎ¸­†Âh¡V+ÂW7[*E—A}%îg<šÿ¾-Ü=?’l<ŽN»ëÇª%2µä­(Ñ²6ï’z™ËÒõVp¥“eñ(5¬=è"ÏúËŠS6Ùß,¦éB\ã#NmFÉok Ç†nD°â†~"ý´D[,°(«´E^8K_ Ð`´;TÚVš‚<ÚÆ˜<ˆá¬&»TG=¯¢¿¾øt½=OwÓ;So…IüÊl.Ô`=wë¦@æä
+M* Õ…‡.%¯Î<·«VµÞ°©ÓZœ=ë–¹_«=ME¬äº®$HQú?æË&7rdÂ{Ÿ¢. Fþgê<ÆàmÔ›¹ÿbdJe{€Æ[hUªü%ƒ_Ìì=ÒjÅ
+eªà’)á¨¡šp¢¥E"xÄÍ—:_7íš^wq”@êã<4R|N©ø[Ô	¾•Øa!þW`¤KœmzajÒF€ÛÀÛDeÈe@¶×KÕ-î3m~+vÿÑü5àIæÊJ<ˆ¬×»òeƒ€Ä¬_®ótBGPAjt²–½µo^€´"wÐ8RBgy*pÅR[ñêÏúéq»Þ†N!°¥´­LaE‚LRpßŒ±P$nÇ„ž‡ö~7€&‹u.
+a9w%»ÜzOíQ.ºø¶ÚÝ•Ýˆ!19ºe¨–p´’ÄõáòƒÀ½„+¥’é­‚œx¾L,S›Fgs«‰ËÍ±°ÂËim#ççGé	µFŸ«°WúùáÐ®Ÿ]†5tTè·@{+úorØµ%;Þl×Ç|Wô*Igb9»…–³½+5x–2 z¼•Üw«œtä­åÌ%ÎtEÄë$ðèK»ÔS<VNÜ®f¤Ò ³©X´!Ymg¥-ÓÔ$¥+xHDHð‹L6êËè´{ï¯c Ø•«Ðù]¿r¬Òˆð@M/&
+tn[‰ÙÎX1Zˆ[@l\NÍ §LrY:‹†&×)Q[§§¢K‚Ÿ®G›æâ[˜Oj*Œ‡“#E¿KªËK¡µ©´t$(ºØý™h¿™+ÐíŠ+<Ž;3¢¨…‚b…bÁ¬d­eúhÑXNY8+£)TÉ¾ðÖ†¥ŒCE[OGÒÊùôP£¬sI®]n‡¼½¸¶y?·èì¸&]š¸ìüÕ:"rNñWÕ~¥‰È)Î6I–|^;;/v\Ú\óuíŽßzmÚ¡æÇ2Ë”!Ú;Uu‰»Fžç»Ú@gT”/BÒg»‚ï¡†˜KèbHQH®ØëLžlZì0gKïaÉ»¥fã'ÑžxAy`¢D‡‘]”šIZ¸.™¿Æ¶€MÔhšÔ1»å‹•_´`uzYš3ÛêÖX«QÄíÜl!,Ü,²¸éiÝÁÂzÆ‚qáçô8"	¤ÑM»Zý´£²
+6(o 6×	ƒ“Ó}~ØN¬þ¡ºÆÍgÏÙ©im9:<3‚/U¬¦ÛÍxVÅlDGu9dÁnãÊé‘âÃm‹<ö­«ûÃökx—Å\îl½	 {r‹^¢Ïd.kƒ¤GBºG³v•IV¨¡ó‘×’Ø*¢ÏJÄˆÃS~×8„ëÔDË1	ø!‰£ÐRŸOæ¿c«ëµ_8íÝ‚ÚäDGÑÙk-Ø¨]Ô”2elÞ¶a¢U&›9Ž›£B&Á*u¨[aþ‚ž¤9Táê‡¥cÍŽÚEôÛÖ±M»6œ†ìÉÞï#Ÿ!æôƒQâÔØJõÆÛ˜Ü4KQFÄ*…rf¥*Ê:´OÁÝËdò¹Ñƒ¯µ€yÀ‰Ð.¯Ì"Ó!æsAS- OPPÄÜ\•"SÙ™6’fƒø³G|í$ôKË<Ö(äê‚”G;Zí.ùÊ”P±,/­·*ÿ*€Æ¶t8ª™Œ<XžEEžÑk UP¤ÚÒíJ¤KPv3D?˜Üî¡×]Ì~I¥p_¢\ÄWÄªÔëÃáá"-¼Ž¥–€ê;¦ÀØ¨—?ÔyØ‘¶°¥.‰ül{è"ejÕC´\}VßâÝ3Â¥èÈÔz(²Ò8Š"Z
+’ÊÉþˆþb28s€W8V4 R2²‚Ÿ?ã-S·ªèŠè°IDñ8¼o</ŠãŽýf3=IØgØð?Zü!êÉ &åõ"ìBïKµÅíÛY3Ñ-(ÐÚ8ëû
+³ƒ§úÇ¬?›~r›(”ÀÞ“Èï@vßÃ·0»‘Ó ¦qëO»±ÓÝ‹˜ê²Í%d7 ™6ï-êñž¹qˆ|C<¬3Å¨×Ç¡^û-Îåvj×‡Û«ïvêÛt•®²7NN?jú7Ç£Ò`Í”\å^þö•ãä¹à–ê²ÁU¼çF}˜ê œøz¬«=ÿh5h5ÿ´šŠV+ÐêM×ÿ®ÿ©¬ÏŸeý¼­¼­7x›ÿo3êC«Ú‰B»éƒË0ôæ²”ËR~ç²”ÿËÚ–Õ7,+õe}<±ŒicÙ¼©Œä¦²þ¤²ùFeXÇƒÊØ(n*ówÊ°ô–õöÀ²1X†;¸±L©scÙhoXæ[ÚX6z`Yœ–Ñ„>°léœ6–ÑyÞ\†ª¿¹l>±Œù#–éË`To,[,›óËÆz`Y?X&Î0CÎÜ`6Çf+¿ƒY€†ÀÌ[ÉÌ«³ñ ³QŸ`ÖÒÌ˜6Ìú;˜µö˜iÖ»|ÑŒÞ‹[ýdu›ÒÁš”år{5æ]9íàÚëï¿ì5+oû÷÷ÿž2yZzZÇlözî¦@[%í~'¤õ²Og‘OœòHl(È)n2¡¶eØ<•×¡s…BÞ÷gSB•‡î?±.¸ç\x·µën‡®zM:ÓIƒQ:$¥!YØÇÇË„/±Mu«ßþ#/[àÂÒ=>Ý&Ù´]ÂÛ©Ýo‰‚ þ˜~ã{»Âyg¦=¶§‰ßôQòPY²®L-3ZqØÊ2òVÞÀŠ–4™«UbBÂü™¶\{ßDh\ñŠYŠuŽ˜R«tM¿¤¥j‹;zÉB`¶,éÔT
+úè¤Ìeï'™À‰Z]	-*OÕj)à>”±–y²h•ú,D.û»kÇG9ÙØ/\ÈþüµG˜„ÚêZ·ŸÁÝèÓ@±‹ùw4 !>­qxË|xJLÍ­eûŸë~`½åã4ÈRRSxˆDòV~æKÏ5¾â†^ Ôÿ—GZ†HâGÏLÿó{? TóèâVg‚?[ÔÃakYg¿ËÃëÏe×UkŽÐ.á¬3FŠHQÀût×Ž+-–ê–ß™á<Àkþ ¬Eúƒ½IõeÏ*«ˆfr&+æ¡jöy¨QìXÈ`kÍ2"¿yÃL]jÎR6¸MürÝHRTO`Û„´}S©zµÝj!(ã)réÑç öâ :ŽLb¯ãîbÇ‘MPaä‚™ijÐŠ×Š5Z§•8'ÞUÌ‹ ²¢E¢~{ ½É“Èí¸÷Ã“Â[×ƒæ=· aê\ÑÇÃáj1½»8!špõdîì}‡dA¿´Ëí ¸p$¬€¦Ó²‹-,ˆ)»0è[á¬šÞ«º'I+Ì­Üº­riOmÚ¸H²Õ¶tœÀ#Ý0ßÕ·Öqg¡ƒ(°´_cyÍE$€ö¨þb0NkÕ*ªÙx½˜í{¦§¹ºW¤%K0(Ü'œÍÐ
+ÁL::+…<ìq5­*OgÒ†ÀP:XŸ©CøtÞé.)wØàxZ‹ln_?añz^ë×²´-©9Òèð–³Ú í$/$Ì|è |±$t†j
+Îá†=`f€?I•‹+¶†Éº ‚çª(ª6ª ›ÙÑ.úm¢KÝp{	ÈXÝ£`¶>H!P-šY`6œ.`'¬1.‡2eªÈ¼I¯á°í.´5·´àúLÐ«²§ÄÈoÃÉVÇ/\×‘ÛÙ/r€Ýî•Ódà°T‡½`ÇÀa¹²Ü¡„kc÷îË…Ã Î¶9Úà·«7¡w$ƒ±Ë$§»½EÐÓ¦ù›…«{x{ðj¤Hœ2=¼y,ÝuX›B¥.Ü=Ü†•ir!X~3‰Ê…ÄáÎœ£ˆ{®ÃŸx	áª~x.ÂÅ.WmUXžÛÛ¡ÜXhEb7Ê|¸»Øoz+#+Ô="ßÕxVâœlÐ2Š#r‰ÑR±<9‰™¹9ËÕr7¶VJ”ÁÊN©WÃ(Ù‡Ò·q‚ŠÊSñ‡F„çö©¼ƒžkÔPd?•´-N,|žü‘wÆ©ÄÜï—BBcY´ ¤ò¾F‰	[a–þ»\q·,DÿÖXI~¤pYÜ­Ÿ©*×òRËå|Éá2ex‘¡ÁðYv/•%b›Ç,…–€úzHsYáÞ0~rë––²èê¥ túCÈ-ò)5)ûBÕ‹xÜ´…ªEa³D[¼^Ê‹B¢dÐÐòÎ™ã5ìmÈõüäW»½ë#òãÛµT€˜ºªåÚIÍ<³²Ë†±Ê7ëø{:z—R¶ÿÃ{™$I’ÛPtŸ§ÈD›s&ÏS&Ó&z£û/„?îQÙ2i!iSðôÿœ8<^,ôyÙa$76s!½m1­?ð¾À¿¢kTÕÈ@È‡CR	,p^¡ˆ>×™Gé¯sv?7°j ­]­?Tt­ÓJ³ZŒ^Z´Cõ!IÏ=ÆUü²‰1€J’­ªðDà<YËƒZÒ±E¾]±Ø;ßË¢k½Õæ&ˆ§"’³,äòèÐZ²šø*.—CGþ|®2ì]ú4`åÞ:ˆg9´`ê©ë[Ì„ÃÜæÀ¦ûÓ¡Tæí('dTR«íhV‘__>Yû{£pì¤´ç°c\|ïü[nJV,‡Ûm‚¯½\€Ó„au.5p)”°—­š˜Dó)GÜ{.c¯Ð&„”*Ù*T>Z±ûô[Ì‹»"·¬7Eÿ÷Æ>I×K†é¾ÔG+Oí8mBÜgùÙžx?º[àâüÑì~jüÑ'¾5fVáAfÝð*—Ãj#ìHuÃÅô”Â‰ €et¢vK{ ƒ•;æº€±ìM¬d[ñ*„}ÝóNS›æ²¹À¼•i"#4ùy2Yò&d€Ï¶3u»W=˜0ÚÚm,
+¤§öQ¯ÙCþk‰³Ë2âqä¥¨AEƒa"ª j^Jâ‘O¸û·Ð" ˜¶ŠÕ‡ÓÛ°éÑ¦ál¤«=Qé„™hîÃœ¿¾,xbmµ±ømÞðë«ˆÉôÜ{‡˜;C
+¤BŸ5ì£é8eÏàž€Êr…Éí!è,)çÆô¶•œ[%2™¤$_>`F÷v¥I{@z¥#ädWU•MNÏ“Ä£?¶U¤ÂñF_¤Ö¬47¼¤bÛ„„(\5)‘¦*‘)­ßwˆ“ÊzÙ‡²âä¡Åht*_>‡Ð¯§Vzã ºðÆ‹R¥;ÓÄ@hÉ8ØÏÒµU´”‰ˆ¨Ï"‘&ÏÊ EÁéutxnÿã'Ut•¾=š:¥úMj“ÕS‹“ÝË$Q¢@2àk¦£ A
+sS eDoËL_>bHñ´à¦0…^Œ¨Ï¢í!YŽ=rFtwàµK–2ÉdøŒóÜ‘±ØÃ ‹]Ö/ÏD¶ëÛ´G´¢’Æ™¦ícGæßzªÝ/rù+l¦{lŸGivÚ÷¬úÊ„#»Þ<u{fÒ²ÄNƒQé"(Â5»»ÒO¿Y|ÔSÖ©_lŽÇNf×§„ÒÃ)Ñ&ýï_aùv	Ú­)D¬ÅŽØ %ÝØ$,”m2÷„›ˆ\—øqÏC¬¹&÷jG×öt›°Ì^´ˆîƒƒ²£q;<ýêèÔB‹U\²^éªÙaY{Á8ï5½C’H†ÚºÍþO¼½fŒPÓŒ. 6Q±“1‰î¡\¿—€ñV £ìÅ0HoË<Ž'F3·™TÇËQà¾DI†Ü]ûÇ=9v		×7¬ûbx­­ß2ùØ€>©n?ÑžÈhš0K¦pJHzP‹&îòB !H(n1#±›À`úŒ¢__K#^æN¡~ÀºD<+ê›µ°!~Il©Ñ«e•ÆÚš}ÎÜ3^œsºˆsÀqO@Ž8Åî+U-Zÿlzé˜4xñûK`çE¹‡èXˆ­X9–là+.ÚD”ñ”Þ86$#2»8eTV¥^ÜéÄã§ýTãH¬ö¢¾ÙYZú‰Nâ±(ñ}³ ´€¶'ab‡YK`F»¡:hèø†¸©a×kOG?HZ!ú
+Œš˜š…i—ª>´‹9Ê¯ªï‡ÖG,9s,‹‹ -jŽ=]%86wÛÎüs7úïØk¤ûŠ6®iA0Òpar‘ÕRx9Ê±	6…o2ŠËžFæåþèEŽªàÊ¦v†ðo2/ÏdÙ/]{
+ÃyùÂû\P·¾¿Ì½¬ì^–nDÊ|JÁs¥Y&((]u+€û4:©÷ïÍ¸˜?Dª9	+µêßr/?£LÉ{Š‘é@çÐèq€0Ôôó—AÏ/þ^©·¸¾ÀJ­o1#/8Aü»Bà¢¾OøŠ:¹Èä'?¯™2jä‰}<ÆE“¨Gã,F¡îáÔ3:‚ü/·r×È!`‚¬•@| 2ë¶1–’žÄkÌí·äTWõ{gZ‘ÓÝ…Õ­ßÃrž¤ÿî·œ£øÑ1yD‡jä¨8ÓÝ(ú©YT¬2ÉL —…äøPUƒØcäö.ßEÎxBc%¯}Q¯çÏ8ŸGÚÞ_µþêÂ)ÿŠ•S¢«Ž"‘Èªºq®¹%J–×Y?†LÞÔ©6h*8f†b"Ö”S‘"û—ÀH`ñ{^cý· +ý «þ‡Uÿ=d}ÈûŸÿ3yoGÞÿ«§u™l¹Y
+5=
+uíJ&´+}Ú•þ5¡Õ@+€†yá ZëO@ãTp mÜ|ÆÎxðY{òÙ˜O>ƒ=øŒ~qó™ï5Ÿaí@kO@ëãh8…ÐT=7 õúhm|Z?€V6Y	Ð]7 Íò	h}æ'¡oB„FœüKB[Wz†Ö›Ðæ“ÐÆü ´¾„Ö€ÖÒÑrYDãF´™>­=’&D³<MØJDëDëõ‰h@ƒƒh¬›ƒh¢ÕÚ~"š¾zw0é³¿å)(ŠXjúþÇß¿ÚˆäWTHêxÏ¬„Ù¼"õû‹§¢ßuï-œQÑÌ\šzE?”[8±ëŠµ…l­.-¥p²€”¢Èç ®wcdd²—®(øè•ƒ¹Ènd/Ž|û©Å¹Y"ákJAzªò4hoZ„ŠqÑ‘åBƒo¼öÏwb¨÷òCŽßñé²ò‰cN‡G¯LöaÇv »­±,QÍì€‰mË-ÛYê¥sPË\(z/ú"‰]'–\éO(DŸ­W÷˜¢Ã"¡t­|¢8ÝÉ(¾±…ù\zbteØÙÍÿ¢ÃK9ÚöH¼&ÑkrcKÖÂŽˆûB'.M*” io‰m†®Žçü­eFLˆ8©ß!¡ƒ¡ð½ÃWÆÔ†ƒ¸¿wìÒ£ó:ô´FgcnÊ“2rcÁ•B;­è½q”©}Åþï}_•ÇAè5:‡HpˆâñÏ78:zÛ¡^ïw8Ð{IDKüûv¤Åé—ÁüUµÿÁ÷Ï¥yÂ"»•§Ó×îW<¥»%|Yÿ½ã¨j=7‡ªµµ_ä@Ÿùõ¥ÐËxï0µâ¤ñ’2Ï—v€h¾€õj¾p6¨Wý¶_©U$K2Õ*ÅŠ¾«þ¥é.ŒÀ+ŽE©Ek]+ŒŠ©BóÆK’ŒÄÌ“…I’Îž3¸a2òL¤Ì\ÔXb Û0,„lÊ²F
+¨[nÔ¢Uñ—LéGç‚ÙÂ9
+Þˆvïl®Dw
+5øptÀ(GÚK„¦pÚ(UkTŒA‰ýÁá)4ñÇ(UƒW’V÷ó
+Z½øwâpi£3	5	?j¦’O50[É¤(.¾&®-RM¢miTœôp=¤•$$'À²J˜ƒ`‘š')zt*õÊÅG˜	~àé `FÛ2
+›>X9¹"q>À—_ïH‡Ë{õ×ìéƒÇþë•÷Ÿ¹×Ø©Që~*VJÜnáÇ©~Vf/<\:QT_÷A„ -5éÄ…ƒ1o8 Ì9Úr8	OI0ÒŒ«ß…>Øµb©ÆÑÅ@‚¬¬Ã{4D°.¾ª~Û·°Ÿ7âtÔ /˜~êiB„¡°†óÆ&õíŠvÒÉeAT ¬Îùg¨¾âáŠß:f5—BW@<*+¬T¨~Û[ôbÇ	à´ Aª™¾x-¬É€Å$ë8jJ·Dgž>Þ§-ð„³ÉÔ«Ç—“«8òµE1¾-°žÇŸûæ>ÊÉù)¬6‘:|íÖ¢üëD½(#Ž!jÞ:Zc´v“ÔdîûÀ¢"z©†¦NÒQ¤–Ò½Š©€ÖFR(dÎ$Þ¿…l\;¶˜‚ ñDî’:¬þâüè}±eÿÉ|™ãHÒQØŸSôJàÎäy‚œG÷7o!3»§%üdÈ™®ÈÉ…F¼÷¨ ÊjªQä<é`½Ø© h–ËJÎ€è²—:€ii¹$#ô”—÷•u†:46Ç<´‡–sqhÙWÙ–ãL}ÑAº{‹¨/N¢à+ ëÕO¤Êüüå•Ä*óÈG_ÕÅñˆ+¦Ö®šâ+T2ÐºAiÌYN³Ng°_<‰%Í9n>	jáÒkÖpvéðvý`…Á	rÛEŒÝÅ²®KY?æ¡‰Œœ°½@¢âw5Ÿs„°>G´ì“S¤kåÿ:É›8f,j˜óŠ†£S­·m!!Tì#ùu]ÇT)J²{¸þ,Á?ƒ¶R§Ó<ÊÏ¢¾ðÂ"©¬ž[ÓcesJU®s¦*ñ¢	UÃjä‘'&Vû0äVé.uîS§p0Ök	Í,ðïqÒX¤jWÈè­‹«^:mèŒtú¥.?¸ãôzõv+U»’¦ßw
+S“k¸FwF-'g	ýNöm†„Or–R¿ø$e@Y´ýîuŽ8ËÏ“ý/½«³Ç*ÛØMÏì·Â³|½õðê¹v
+ô¤Ú¥9|ÙC*Á-MJŽ¼U½LÓtõ[¦³u>â²Ð;ÕrSšÐÉtmÈˆþ¥QÿŽ„¦Í[
+©2r'åbRãÛ]r[ô‰Âê‡w.CÅNóQ
+-”z*}È`qvvÚoE—·‚8ØÖˆp4»hé ,âL¨òžˆ.t£Ù8âÚ[.ˆç¢” cä×ÛþÖ>c‘édÞØ$óÂÿb!ÖÊ¥ƒÒñ+à¶!‘7æâL•MeZ5€ŠGûÅ›¦ñ7Trßy½¤,ˆ$ùï}+ö>ÉÇð0Ûu«¿­Ì¹¤Ì¤Zk3_Ý¡šÛÏÄ<´ànVTÇe®21£-VgÌÕäl•ÑÆ˜‘:^é4gËfH.•:¢NôgÍ;²Béf_ .øY8kž‡)œCEž[ŒöbYÑIìÝ)û["xa‚N'Ê‡É6wh»Øâé&««]TÑ‡qk1F,êè­*2M³›Ç˜7ŽdŠ¿Õ¸€çI™är Àerì}ØãdÌp²:oâ§Ë
+.ÙÔþýù«°àî:œSÐ˜4ôç/£‘{ïpO„æ|…:èÖ³Ó¿{bO'åÐG‹§~3çÏ•©N´K!óØÊ¹ºuœN­}ªØÎP„ûÇu
+Ã¯l:âAö^ÏÿÆyêµUà ¢/JûÜ$ð’vmÓ™Æƒ²¶†—vO·T"¢ûH½TöÅ
+ýñi,lJu¬ß§aI›ýè©ïwcæñð…ïJÚÎØ@®Ôje,|l Þ>¼Ëµ)ˆ+Âd%ÈbêäAò)TGÚöÿjàôàžxÊ|¯\•tA‹S\¶;Úìr¶TñŠÊ©×bÉD(xš–ÞÍFx©V0›äxU¦jLy¸­¯°Çöxp¡„±µkËfŒ
+øJ“õb{Z@D2±Qö€‰\GÐlÝ¿'‹ª+v±£*ó½r[	'Þ”î	¯Ü]´Ü‘­Üùr÷ZÎÚ&zfÊí¶¸ýŸ~[¨@©[…ŠÝÐÊ)Y8‚K2D ¾O“YkÔG^¤V‚ÃÁCþð)À–¿äi¯¬Ý]?Rw‹z…æŽŠ'ŽÄlÊt{64¢ìE‚½Ê®É1iJuY÷ÄƒÒÉ6J¥@d§C•ïÊÜ†Ý½'”Ž®,…dìuæu®¨á N½’U“?¶%D¸Æ^3Î{x/F"s²~XÀo<„Gsø?ÈÛ	 [n,Uì«Íb8|™5.¦Qòz¸EÙÓ÷ŽÅ‰Çi¦„BÁßi65êµˆ´Üãc=k.¹|±±øiÎH‚=	Rí@;Ã!{EzFz[üáÚÓ`´¯½úçç/ãþÈòÕ‹#•h>Ècá¤ñ†®Ú–0ý(ìeËÜš*­ÓI{vÃé6ª¶Ü%DÍ‘·mEŠŠÑœùÔë#Ø„öm†{íš\•œ±‘ú¾È¬(PþQ‹	AD¡ÈžGF\ËÜ]š\(@X£„ùÒ)Qá![£ŸicH`'g?—”Ô%)J¡¹m²Ü*õô¤AüBã¸4º¸†%]l¤Oxøßå¨Ð¨ŠÍv\(2bÙÑk—p˜ÃÕËŽß'úÜñ–1ÇzKÈ‚
+®}:=úV÷uÿL8ww—¾ºrÂ1ðotÅ‘SÍê±ÐuŸDbl¶[R ¿Ñ›*^4TŠÙœ¨kÓw¥Ð8S/P¡¶Ýƒ/¼ÏµgÄ•$ÿn^H¤gT™6Ë"ÉrHìl{ötÿ'´ž9ö¥cŒÊ6¬¶û7ìJ3˜"œò5>¤²Û–Cx	j†’ù’¯L•”@Op¥õåúqmC„&ˆœ!¸1V´Ã÷ñ§§õÈ×W„ÌeñÄ>ã! óžbL®{àÑ<¨xø’?€éH‹BP4Pi‹–fmºÉü~ìáæ:ÓâÎ¶"=¦»1]6_ÁJ:;›T.Rä"á×}ø?¦À¨¡üðÿ»àw'áÇE(¥„àôY1žÑ¬!rwWï=ëá¡p=ï}ÿ²VÿçÁóÿò@õç…Sþñ=ž:ÿ%èˆk5Í»Û N,0¸—?ðIO‘´êþ#F¤ƒRñŒ7¡˜“AHñ=«ÅôCUù/QÕüo¨ª¯±ê‹¶ÿþ_j{{hûQöÿÄm„Œ¿nZÒQÈ6Õ’Öž@†Æ;@v¹÷']j—/|Ù5<†¦}ðX]_xlõ›Ç¸„Ãc­Íc¥Þ8vOXJËƒÇF¹ylµ0n ›¹ [s™³ÿ$2ÔÌMdÌßdëúŠd×õ@²^DÆÁóAdÌÛƒÈÊ¼Dvõ‘­ü$²¶þ“A9n&c*“‘’6“!-7“ÍÔo&+BN1Ù,óf²®!w3%é0ÙÌwÌsÛÄa2-v3|ÒP†©pÞP6kýe+? lõÊLhÊÖOHßº#Øñ×––ô	9+J±\Èêg“kYñ?ÿwÅ'Ñ 6’?þù'5œpl¿Øu‚“l™„¹ÅbcM-öG©N>×e¤tô%¤á•HHu¹H`)¶ÞÌQw	HRD†ñbŽe|ªEic,[…5”èÊ!§™õ×Ug1÷3A&,JA¤{ÿ|‡öEÀ9£Ä6üãw|š†ã8äê‚Êdn$R†íDTy4è¶`ËUQÐF6a+q¾ƒý[¸Ðx&Ij|.1XghëøVbAOØomq9*CO¢"atØQœŠîdÉÞÏÅAfFL^úü¦lSÖ‚aŒ(´h†Úö"—iuPˆ&Z/‘8+¶ÞÆÀ8Ã.ôºXpWa™ƒ¦Eê÷'0¡ð½ÃWy¡–Óã÷w4Ž<B´r0Ë£ð¢†C42KïU¼"ÞTc§^œ¡dŽ"#“´îØÞ÷…ÌnðkjUÃúQ<þùÆÌ¶êP¯÷;è½°~„ú÷íH‹Ó+’)üU¡ôñ ÿ÷¹ +Jkõ…ŠDÄŸFÏs¼b-9å»%|YÞqT­›'Ý×/r Ï|þRèe¼wºÛ8Å Ya^¯r€h¾€õj¾p6¨W}Û¯Tª¶Î’l!7)¼58²7ˆuF/Ñ4!Ø­‡ ]¡Ò_FÂ6>Ü8ëmV+ÛÅÁk‚'KgÀ[aÊ¡ìEéÍ!Bƒ€?euÄ}ÑclwL ý¶™âÆõ7Îœb`Áñ/š’ ý¡¸\£â¸©Î>bxýyJ5¦&PñÝWÐêÕ¸›B*Àæ`èZÛ¾÷ÌƒIÉ¤(.¾ÆÓF ùPvK¸©ž‹"ÀÐ!ÄBB8ìx€œÚ=*2×³™9Jt•êàÀQÇóÝð»RØüáÐÀFþª­î¤Žá	ß«ÿ†¹83”ÖÿõÂû¹ÔÖÜ™Qç~(ZTKÃ ×c˜ªž…9èër–XL1‘û8ÉEëÚi›¦ø“Ì¥ÏàýdQqGQ§‰˜NOöC€íT]gíñ–÷è†‹ßu»,j®ámEÿb¾Lz%9ª(¼¯_QËn¤49Ä±5XBH,Obeµ6TcÉj6üzî""ßÐÈB,%wÝz™Yw8÷;'³-¸¥„sã^8û³¤«’Dyœ@]p¥ˆr-€[6WÜœîê¶&K¡Ë·j&ÊHŒ“hïÀ[Id«h]ñNðµ 4¤XÏxÜTµé"—gÌÔót„a(N&^.Š·Ûm]åMÚµ('yÍu8{!…ß§$@Ø«Ñ±!¨ì¢¶0XQ®»¢¶á4›ÌCLt] œò=êžrÆ.:4µ`âdô
+g)}X­C˜H!t>§HçðöVbKó
+þÙ1M{KjQ$ˆJúçy ÃtY’¼ÊZr9J4ÀK»!ÚÖ•º½]ô:ÝÒmüåEÓáÊK×OÅo‡:rRáu¡Ÿ–}çª…Ñt;£¡3z“xË­lC]5Ä yµÌqØÚÑÏFedw6ÝÒÚÌºo=^Æ¬ðN0Ë0§¬}&'©÷œ,Â¦ÁUãpöxòFÞ+kBHè‹@’â	w72BXvÞƒuè%Ð§Hç=ÎñWçXîn§‰1eZ5Â!é…K9õõKF;«0*ÕNnÔsx"ªV~Ýéº›¿¦I_´rß”ô†F>R‰;è?‡¤Ç«Õ*Y9GMÝã£) 2lGÖ40qeM9‰!¸Jø®†K(Œõ\23;üe€T¡Ú-òênV†…Ýuœª7”FJ½hÎí8Á~{o+µ»Ò¦Ï3‰+QzðÂÏhæÕ¹EJ_‚}ª!b%rD	ß˜žíIê€ÓèýÛ-Ë:¢œFþŸM¯Ê×Lcì™þ´3Åì`Ÿ=–um}
+zî=9\¼FÁ.NšV-WM3÷¦ÀâP®¡ñ›4…C!ÜS®µFwB*×³SFL0o¡]“qK!uFJ¹¨Èøí,ÁÀftI±ŽÐúDñÆA·	Q
+­”ºi4pó^à¬}TDuyèse½ ¯Xièu½žµƒ²ˆ+¦òšˆÎDEÇ¶qÄ7$D\›8:òEzû¯õ
+‹K+³Æ©'þJ¡—V6•IÅWÀSC"'ä¢¢Ê¥ò¬@ÃcúâIÕð2Y‹/Š¬ž’D’üGg>¨GŸŸ‹ä?Ã:ÔtNõ÷j òA/©seSµÖ‘ïè¡fÛ÷„‚qŠ«ÝAœs…!­±7ÈÜ 
+Ø8¯Ê˜b8¤ŒG:Í‘¥C4—RQ&ø³ãQ ª/ö”ß»L›ƒ2;¦Š­v-êÄv¬Åqr«Ö_¾Û„‰:(K6y>)"Af“,,®Þ¢cJqÞµ¶ÚÔmyÇºK¯)øàóÆPLá·ÆVô•äë@€Oªdéçð’ÓfÆ*;ê~®YÑ%GÚŸ?ÜvÖ"È¶ê“›Ül¤û=ì†Ð¤¯P5€l]'ýåVÌkAiSxZñ^œùÿí2K÷*ž«§3™öñm×q.kTí6\®/­3Öâ%¯|:b)s>Æ_£¢zì¡Ðƒè¥¹vX ^i,jBØ[×ð=MsK-*J±‡Ô+@o?Ð®B×£áPêd}Vß²«#’6û TîÏ.H¿+qÎ!mg[­¶>ŽOwŸ²uÈD
+bÊözš6"A–S'R°Vu4¸­ÿUŽÓ.ÀSqú|@tÈŠŠ©—Óh#¢5ãÞæl©ãG-f=k‡X"u5[ã°žêØ“-%¬¶âÁ>ÃI8ö&ˆºA$Q:7' 3~%iõâx¯ö…ÖXÙ7k$kä’æÕù[±‹šœ@<ð`y+ÔÉÑ!•óµZ·’N<i&oŸSÔ<’iŸ¹x|-h©C½Š¹ni.¹þG?-d roŠTŠ¶)m‘‘PrÑ³ËŒö3f±Ñù uØ%Ð:1<ô¿$èú·Úîí­×›ÜdØ †)G¦rÌÅP˜N™žÎ„9Ô¾Fô­"[H“¤èÍ„‰Ýó s¶»ˆ@#2ŸäÕâÕv—Ñè	¥ch#K±6œµæUV´pð¦é¦é;!ÂVú;£ÜÅg1	˜#ÐîÇøˆ›Ö¸DNü¿ÝµÜ‚	 	Å‹µf+i€‚í§£Å5J^Žm@MFöô{cÇ	ÈLiaÊ¼n#Í¦F=Öú°öÓþ8Ö½Æòåþ2qøÓôH¢nƒ©úf¢È¶¢èCÛI¤ÝXã?"NãÆ4þ7Ák>üñÃÍ´ßD²|´øR0èÑPiüC(×‘š(}ìé•Ù%U2­JÛ»¡º‰–AË%4›Ú¦×‚ÑXQ\‹|Ê	å‘x F|ÜqKïÉvó§bâ…ÐŠåg µ H‚l;R¾ »Ó­•/ºÅaå$˜N‰Ù*y˜"}­ô~n)èKb”Bƒ[åv€í3áƒCâ’sq?+ºàH?aïÀÛ&Q¥UÚsàð‚7Šö°¶E‘#j÷?F,ô™q—1ÇzJÈ‚+¨ä9é1ÿõðÜXö‡Å™ÓýRúŽV£Ð¢Y*A»W¸¢ãÔnµ+tß¯‚‚AI|goª¸m¨ð‘Ã‰¾6~gjqvjÛtþâ1¾ÐxF|å/á^›CJ¤§ÚÙ¸mXH–CbkêÞÓó¿bôh1¹÷QFùVm¼nögí+T^J²²½s¨­P6éaæ2AÓP3-–ªžè®únÇýì±D¿rO‘\oÔÃGñOÞ.ùzý…à)#ŒØÕ19§‹1·Âð”a?mTl¾´žŒ¿\H{B°ËPé€Vf²ÉìÞ»¹9‡[ì¹V¤Ût5ÜeP·L»ðv?	PbØ¥¯ö?l`ŽN%’ÊeÿÏ†ïc¼
+?ˆ¤T±wàÑr_`‹–»›wz=\">Æc7Kõ«x+¬þãf?õú‹Ñýñ{¬sÄwÇZç°•*ìãÒâëü¤]d&#µ£F‰©Ð *Ö¸Zy5	#^&5£™þo jûYPUÿ¨ÊíMªz&íÿ—Òž.Ò>„ý?aãgs›^id*Í2h÷sá1Þà±ÄÝ?\yŒñgx¼òØY.8†™½àØÑžáXËÇø
+ÇÄYÇöcÒN?h¬¶+Ž•}âXK_L«Û>x¬ÕÎcÎþÈÐ3È˜¿Idí|Ndçy!²|\€Œ¶ódTìíõ¼ Ù™/@Ö¶+¥ö9$ƒrL$c*’’:’!-Éêš'’í"N!YÝëD²,‹Û‘Œ’4¬n3ÆÚ×Ä@2½lG2lI3LaLVã“µíÂd-O&3 &koöÖŒÎÈÛó‘ÖùýíË'4£ž»ïü¾ÿô×Û/Ÿ¶¯¡„O‰2Ic»µè|ÔòØ¡7‘ã§·w_>þùÝý7?þôÃ¿~üÇ§oïŸþ:Šÿâ1+Î·EŸ~}{÷ÇïøôòÊà n‰‹¾½ýÉWýá}4Ð»Oß|øûû=Äãþî»oßÿùé·o¿ìÓ/â>¾ÆçnûêéöÕï~u¿ý[€ ò–ñ
+endstreamendobj215 0 obj[217 0 R]endobj216 0 obj<</Filter/FlateDecode/Length 327>>stream
+H‰\’Ûjƒ@†ï}Š¹L.‚‡xh@„Ä&àEÔöÌî˜
+u]VsáÛwÝ_Rè‚ÊÇÌÿÏ8³~Y=Wª›È7ƒ¨y¢¶SÒð8Ü`ºò­S^‘ìÄ´’{‹¾ÑžoÅõ<NÜWª¼<'ÿÃÇÉÌ´9ÊáÊ[Ï3’M§n´ù*ë-ùõ]ëîYMPQäÖ½4úµé™|'ÛUÒÆ»iÞYÍ_Æç¬™"Ç!šƒäQ7‚M£nìå=å{
+•üVÙµßqé{›QP,Žö+E ƒ"P
+ŠA'ÐÁQ|p¯t%ÐÙ#èRTH. x¦è%M@	žé¨­.g\2ô™Á%ÛƒB*dø¿2t–¹
+ñ©Ä\ÎnŒë¼–Ú½Óc[ânŒ]”»nCËn:Åû£MVµ<Þ¯  Û)¦:
+endstreamendobj217 0 obj<</BaseFont/TIOCWC+ProximaNova-Bold/CIDSystemInfo 218 0 R/DW 1000/FontDescriptor 219 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj218 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj219 0 obj<</Ascent 1079/CIDSet 220 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 221 0 R/FontName/TIOCWC+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj220 0 obj<</Filter/FlateDecode/Length 27>>stream
+H‰šÀ°J€˜[&>b$€ À ½
+endstreamendobj221 0 obj<</Filter/FlateDecode/Length 1555/Subtype/CIDFontType0C>>stream
+H‰d•}PeÇwÙÛÛÊk‘]ö|YÜ½	ôˆ‘›Ô&!œ-AÀŒ¡;à¹Î;(í¨Ì4&Ó)QÄ
+HSÞä´#Þ‰ð%S§43_0ŠÌ×†Fë·ô;§ör¦ÚýkŸç™Ïï÷|¾Ï3Kš ‚$ÉÉéIÉ	+"SJmåÖ5¹KlÎÜYÏØŠÍþ¹hETBªt’2T‚5Š¤|‚O¢iùë$¢éÓ…Âò@Ø¯ëf„hStaM’Zö¹ts¼Ù–gI2[JVGE‚Í^Qj-(t2#^Êœix!·´Èf]c+)³•Db¢£cgâ‹‹ÿ.*3”ZÊ,¥N‹y¶ñÙ´ô
+»Å0Ç`¶äÿ¯?õ¡ˆ‰GzB$’ˆEÄrâE"‡XMXˆB¢ˆ°vb-QJ85½Aú×ë	½ºgbA”ÕÄ%r¹ü€<BÞXÐMM£R©ê õ£f¾æuÍ ­£#Ÿhoh$O5·™RbŸÆ‡ñîýaÎ6
+èo ¯–ÅÝìïnà”$àÈVƒZ˜AµÂˆ€q?b<¤AêÄCÄÅB¦bš	ã0NR"õXYp!°íæ­›mQ(±†:ç¸ÑEB6L§àŽ~ÜˆÌÇ‚Ë& šö•3ì•*RžV«)aF)]zÂ&žîÆo 
+S¾„¡³#¬q‹¤Ë³èîÎcçÅ#%KçÎ÷a–Œ†½Xç	‚ 	¸*·!”¿ ¼¢i‚b•\Éà‡¾X5p%j5˜¨å¯C"4Ñì/•0tê›d#Ì€÷ÕfOr»ÏØ/‹4L‡,Xj‚hÌÆ¨é¨ÇP âAwî´·³YÞÀ„'GR,¶HÐï	æâUŽqqJÓ·ÝÞïo¶-X¼Mfqó§ ”³ßDè}#Ãù]÷©†šÔñíBfÏPÅ¦Ý91²’Ž¡¾TfQ^îóYÖ†½k%æUÁlœâ'q›Æ“x»’ ‡ãFMZÞƒÏûvàÊÿTß7Òì^÷Hüwvuô.×Á°x~½âÐÃ×Èá°`AÙŠ©ÇDòö|ô…x²½h•œÈ.Jýx±øttÒ2ß‹Äµ†Ž6n‘xGÃ÷ÂC›ó¥ybFÞ¾Î.ï§}ÞÏ6ØêdöŒèð1hU…Å¹Ôz“`=«õ>öï6ßaz-Ëö¦Š‰1~pì¯F`ìë>$ñë—øÉÑš¢uÙŽÕbBÆÑá«}GÏ~Þé(ª—Ùƒî1ÐŒü9æ‡â$˜•Èßk†MŠ€ÇÏŸ¯ïì•Ò®ÐkŠ—Wd‹üí¹«úO¼)î×BÌL 0LâïáãaH£A†­%\m^’µUÆ7´=Û[_Ù:§âr]sq}…²ªiLÍ¥_hommo·¶ææZssZ½2ý¤¯_P\Èû\û Ò!à)Hõo’÷GzBEqcá@sê¼¨²:•]z¸ÁÜXùÕcO¥Xò‹%þÂ <ÃwÂÌºÃûûÄ/:eìdXŒQ	Ã£•®&—ŸÁïRéü	8Ë4Õihkv¾³å&2ÉÉÖÕV™?pêA7yî;ðõmÒ£^Á'¥ê†„ÌþË¶«"L=jtHÕ?Y+/«¶T7NÝß¸§ëø`iñ©ï'úPæ¢ýsEä.œ‡ÌŸ®áWåÁÊv·uêšµåéÉ	--…‹‰j¶F§÷³ªÖ¹…Öš=É¼Ç~‹Þ¸±bc¹h{µ¡Q†’;@Í„Éjâ“ç#u	·1¼=¶'kTbOü{@ÎõŸ™rÕŒ_¦ê/1¶ufû*qYaýiºÇ[Ì¬¾¥\<ÖæQ^ù†Ý„+69Çç¸¸·”zÞÞ…KÞóvmóæÝâð»'?i».åødœ¦EG‘ƒQC´°Ò÷ZE½Ö½î—E÷+[·Uª×qw%˜Èn0QÝß9žüŽ§£#ß“““ŸŸ#±þÿÅ#Š¬Ñfs¯íR\;wÞ«M­µ5;©Î[Só·îá*ÝÏ# ŸàÜ¶G§}îQØ¬ìþ` +~
+endstreamendobj222 0 obj<</Filter/FlateDecode/Length 4782>>stream
+H‰lWIŽ$¹¼ç+âÃ}¹jè$‚z@AË¡ZÀHÿd‹3ª{fÐ@uxFôÍÌ?ýåçë§?ÿœ®?üñçë•î×…¿½^ùúï¿^?ýéoéú×ÿ^eµk_ï2ûÕw¿Ëºþû×?_¿¼Ò5r¥½ú¾>	¯ÿ~ýæ9°aïÓþòÊWÂ¿|t·ZóÕ{½knåúøöâ›o¯rUñôùªwšåz§;Õ}Õ»y7£wmÌëî1hÎ¹®vg<ç»âs?¸±ð™-ìZëKêÝµ÷À¦0VÎÚ®|½Û?ÌmÓ(s^å^çñîÆãçëß4ööF ±Âæ'NM­³Ý»b‹uï„\Þ“Q¬»Ã¯×€/…f.óšˆ³^ïy„1ØDrá3¾[-Ó*ØpÝsaÃ~wü†3ìøÄî¯}×™J³ñÅd.6B}Œ¬Ïdä»4¾ÑštW­IØY.Kçâ¾J§–†¹73°øã5Q²‰œU80°Ÿ#½ Õ¬ÂÄª†Uz¹˜”·í™Ÿ?^o¶ÙyõyÌwî:ù“ù~žÿ^üëw½5q:¶W$Ù~:ë]òzSo½KAyñÈ‡åböÃÊðš1[ÿ•X§ª+ém
+‚b>½¿-6ˆŸ>_ø½Œ°¼u¬Ã»¼lúïgXvÌ;$ý£[C!ÆßžPE¢÷óël=‰ÝŽÍÊéñ7\Y¥ßò+?oÙ³‹ÁÙD6Ç>…ác>^6ã¬ÏcNvŠ÷(èn Ûû‡Aÿ}~ü@wí_üðÄ§~í‡Ê=€Eb¨.àù)wKí²ÇÁN§ò^øy¬«7uôwdC>aíûšjz6ufè	Àk0F—¿¦Fà¥(øÚÉm6«"@¹*0€…¤‘ÚÕ46y6»Ì$£³7 Ò±w˜èîåÈ0aÝ†ºˆu ¡„Cf%5¤ôx¸î†z¤»x?›,¬ògÄ¿~mƒ†zboñ{€ç761]l—-íI•¦¬4Yiå­«óîCÜ\ÌY¥2§‰. ˆ»«ˆšÑ!i^#W¶÷ÊÊÀ¾¼}€k²èl-€„£µ>s‹”j_êÐ:…m¯ƒÓ®ÁtEÑÞq@X^oÃÞ˜PTsçÕ~czÃÇ´ê¦È‹‘ú#3eRRãmý®ð}'¶ÉÔ6úm«/{>5À®Û”¤.Œ¼…™ÊIðu6Êên±¼Ø;•…D¿‚WGŽöWwÃ—Nsb+õb9×ïÝÈî©¸zy°ñ³
+[»úÔ†›¶×êï„	.ÄóPÛ§œ¿Œ2–¿ãÔ fw96µ1Îå _gàŒŽ©Ê(:œƒ¿ é	'°W¦{!£"6£˜X4Ÿrcö*ÈÖ¤9«:‚Øoèu4›Ô¬—ÔxÞƒ…feÔ§¬€80ÒUzng÷Ýi CSO­Mc‘7À ÏsW§iHÒŒ‚ÀÈëT`°ÊRÑa•ƒÞŸ9™HËh:ä*n24©g">'ªHŠÅÜ×ªhœÀiZ}t†ÜËc&}hSDg‚At[LTÅ•ãìHÉ5çMÈdëv1&ý+C”Q’'J‰šsg*?±cR{¹©‘ËîAÖª:i5ÐÃ {fï·Y™º°6—†¬ú¦7F°YŒP{ÙÅln’º»ud>5>lø,™¥{:hCpgë–¡B&õÎ—äBgÔ»œ·$¼zpËÝ§ôeJÑI¥Êf£hþV!`i4ÏöàAÝÔs?6dÉ•èS’è ìÈÉŸèX íK1«¬+²3ÞbF$U`3qÁú&ÀrL²§‚"Mò2ãŸ’Ép˜©œw‘ZâŸOÚ"§*8*“„*5Riòº6Í‰¢„Ï.UœÛ¹—†åþ¢gNqžÑ›6”SdYŠÜÔ<ÆïS÷„ÆMˆ	†CýG±Ò2{4—Q…W_öõÛl­`·¿iU„ÝÝ§Ù—b6>QkËö¶ÒÀk¶ßÚ>=ó¦¡¦è¿ó'hµÝ–ªÁÉÉÝG:~²%Ã¯/ÿËŽšDóNãô5Í<bŠ&ŒLÁmÂdV-ÖóÀAëÅ¬iýWá?2“ö9®yNæd	~Z¶ Mûà]5è*LÍßGßú>Ø“ŠXÕxk<M…Ú¶iiœ{Šnß6ËAs(!Pð)½=tÔ	'ï·¯&%°V9¢‚œÙû=Ê,éK›d;Ór†?TG¡2š£:ªÝ9Õ‹„c ª³…m©_šÉf SkÕA*ft•Ô·0É,”J¶0ª¥t¾Œ]$T×Ž…åTzÁ¾DQIo–dÿ[Š –ÓÔP[ªTO;^DËØ2¥rnïWÇ…ü4A9	U=÷©½uüÈ=ÜŠiã©î[0°ß)¼Ñy®µ<_e]ål‘æåçÓºHWêKÎF‚Qeç©`‚ñ>ïc†ºã&3‰ò|1¤­îÚº~@x¬êy4š‰ÅBô¹{$ä¦ñfí­Ææ=êˆ›?kF„¿dfì£
+8ªEÔmIƒª<ŒPQú2l1‚×½ŸëK­íDo	‘«Y¨<7OMX­—£uåiZýö•‘ž+‚åD­q“yú&;ÈZàif>–øV-Þ´´¤’3o|ìí™É–-!/âtÄµ‘jiLrŒ¡@æ59F1Ý<†9ÄR™_Š^¬Fý˜…âr~(r£ˆ&<uË9Fñ¥`‰HByÝç1Ï}/ØÐæjÒÕÿÍT\ÈÈÆ Çµ©¡nùŽ½••ç?à¡mëÆòÒøú9H+¦µY+øÇ×¹“ƒ¨=ŠÔS1Ðl© Ò4ñuý€ïiN´rÔ•ËœuFŽ69· õu‡mVÓwÝT–·Éÿ¤I*RóláLƒøã¬ÍÐç^Eý´Ï¼âÀÃÍo1S@Xùñxè
+&4.ÅwD
+L­}Ò0Á0;$Ç îòHB1A¤VÏ!ÙÂzûJiÑ/\˜B‹aBUe>6+Ø%ÃÀ³39a¨J™'· <ZõòH<„C	±Ñ)1ðY¨äšCA¥#š@DÚ¨;¢1K˜bî1‹®Y »?Á’¼Ìaûê)»Kœ‹rÔÆ|íä³v;Ä÷ –Åô‡jzÖK=]h9Â°òðwOC{uWl~Àâ“…ŽþÕyG¹<ôe x ùæàž‹W±¾ÈG…H!;msòšÌ6ErÔ]ü`)˜Åp	HmŠIî‹|–çûa;A^áùÏï‰ëÆ±²7ÈŸÍih„s”¤Ú5‡	GB¿D;œñáŸ©ÊšÐnYú:ã&áä[ÆoùM]?ž¹Êù­ªaØYTËT		­ˆ¤µ€žÜ]Î©…ÞÐMr¨s³ÔpEž…ÎÑÂëž1µ¿aÏŽŒûrÕU/x„i‡¡Î:€n†¡}òàñÆlð>j½âœá
+×Í¾XícŠQz¤U-¼êÿ¬þx²J0®¹:ßßmd{-×Œ}>?Áù|Ï³BÂœ;4LžÁÀ¾õéx6€Tþ!Ý>e¬â•ç$¹U€Hž¹=+,o3n¯ÖŽ!Ó±…˜~x¸€'9¤ú;Èˆ<‚/ÍgªtÜÍ–JÀXöF(íÜgM<zÒS_2Š&ùyÄ#ÚÏÿ3_¾-’G?ŸB/÷Bf-µú/„@îrLð'˜¹‰w‚n6ž½$ßÞÏSU’ZÚÛÍA0øÅ­¦úZ­êîª§~µQ0ÛŽq(,¤²BeíF¨¥ÃEU.ãÈ”ôˆ<Ž†´¨]/Û N²Ðjs`Ôhç¡‘Ç³*Ä1_43)N¥ãR0IM3,˜^IÑKÎ@ñ–Ž„Æ˜J»åþ­~câý
+õ¤WˆË35õR< )ÚÍg,X,B¥àL„ÙArí¡²ô	£=Š—Ù\šƒÏxŠCuÆç)Ë‹í’Ñ§*¯	5§ö3µk[6~8l_X9Êš:K‚Öm£>M=Ñ¥#¹<O3É¶t–
+‡’p9¹‰®q>)è1i½ì´oœ„›ÚÃhkv#ÊôË]Õ	$?¦z‹ØÌæ¥¼Ñ†1å§ü%YÓ¨í`Ëf/ªðH£ýÖ"%÷®‚¥.ødMˆ–U6ÕCÖÐ™‚nµž Ó³œoŒ†Lâ¡Ë$(i'°•N’¨LG¤†Tö„‚¬æ0š[ÄH×»ùÄž(ÒÉ¡…X*Û®ÇÏhÒú#Ò±£Ñ¾RF„¸Ê¢d\«U	ÄvÍ" ë‹CØ  ½Ó­wš<[	àdT«¿Ç“VKÏCgKÇ(ËhCË¯Ò•ßU“ê{x–6Ñ˜ˆ	yÙ;ˆÐO)´w°æI$¤*;%iô"š¬é½s/Ç)Ê·nZwØ˜L?³;\PGéµvéùÀÿ€ä,BÕ*†	…9ëdûQ˜4º|®¼wEœ.€M 3fJÒHMBQ’÷jªúµ
+„BÄúX!¨³Ï³Tz¥ü‹,•–*/±T|‘¥üë,EÁžôüãhÖrþ…jþ‡š¯AÍÿ Æ¸3MÔÍ©î™xÖ æfþbh·SŒW‰ ögù‹«ÕüÅ­ø‹MÀÌ_m¿à/ŽNüåÃÌ_ÒdÌüÅ]NüÅÝÏü•Ã‚¿’«ø«ÄŠ¿r_óWÀÕÍüåËÌ_¼š¿bœùË·5€¥¾0EK0lb0é#g cU® ,µ¥°\* S!W 3Hü,€ye§	ÀŠ¯ ,ú
+ÀJœLßž,º
+ÀJX Xîf s5…¾æ¯'þÊZ•Œ¿t'E_ñWê*þÒz4ñWñ)(uÝ¿¼‹Kü*#½L+Î"µhüeóvÇHLÚ	¢65—7_½k€âµÍî8°Ò¦fwØü®Š´mm›Züs°ßÂÎ0ú±ûO°aFŒ§Îæâ™¢ÎéNoßUÏ–ã¿ßýrŠŠÐìþÈ¯ø?èê\%¶ö¦×ÙòŒ|ãýnóÕîáéîþ¯ÿúawüÏõýátm¾ùV÷å²ÐÍô—{ÛuÜ·†/‰²#‘t“}qt`ÝÇÍÍîþØ|{9>÷—»ûæë»‡sszlž.ÍÓùôÓÓ±ycþÞ:üýÍþ|h§Çëé|w=}:6.9Žçëéo¨ÇË$áÍmóõµyó÷ÝŸ7»ßlnïž†Cs>~:^šÇær<\öÿ>ÿ?ö—-?ÁYXéÇã¡y¸È.×ãA–±·?¨3œùôÈyçá¿ÍéÜ\±…»‡>Ú_Nûóõqš¸ÿ´?ûÃQ'bk‡‡»§pöV6ö,&pnž›kåÜðð¸‰dA Bø!8¸ïoºÛ7¥mn:94Ù).é'œUì?¹É¡ÜJ—§æå¸ù®9or`=ÛŒì¥<†l.‹˜ŽÌ9TÅ !é!.U9kÖh:P`	¿Ht’Qò'ôÁ*N`!ˆ:u¬œ‚Ü‡ÊKƒ AZF+I¯‰¹fs+XÉÞÄŠÔšŽ¼®tã{Á8$SÉýc™5
+fÇnÄ¬;	*ý= ú²±›qZzåEèE'­]´>ñÌÚk*í ³‰tá Ô\WÀÇæü «Ð?Xÿ·’Ó²ˆâ5U\±"C%¹Ç,bŒo„@ÝÁ[ž‹÷­–DBlhzÙ’Ÿ&5š5š~Ö4{Q$ËzWŒuáªNGÝ-(
+p;c·QNDQ6]uÄ‰È£M8GÎ•{AÎ<…ÃÊŽ‹ÂåÈÿR•ÌaX9MuSVô$°bÃ4°…f$G j«ßkfLÀöÁEtC¬83ŠG¸Ž[i¥!T{$Tq©-]?¨iRÍÔ¿Ãdâ:ˆ±¶DæÎáž­n&ƒÊ~$(”,3uq[ÄYWji'f©cºBk=á6“!B#Ï­Ù ®[@{²)¯p5³ÆÏé±…+Â'sºØØsà%ŒàB=Ã^×-ù^VÓ¼F»°ú¹ÆV*H°¡­g·¢®Ø ]W_m`Ü‰-¶Ú¹ÖTTEP.4 (ÐÑŸ1ÑKÞ¾ uÏÄw(ßF’ƒ{AóÜKšçš×¿ªyn¡yn¥yî5Í[I^þÅ4¯{UóÜZó–’’G:[j^Xj^Zj^Xiß¯E/-D/-E/Õ¢ËBõòRõúZõºZõò—«^\©ž{YõÒZõÜZõÜªž‹¶¸_êåZõ\­zn¡zn¡z®R½¼R=¿V=¿R=¿T½•è¹_è¹µè-5Ï/5Ï/5Ï3yº¯hÞØjÀÝVúPþk$×ÓÅÃ·Ì[ÆC¼´¼y;€»…*¨"[úðº“›ïîO×yÀóý7ïšÍÏ q—éŽ
+endstreamendobj223 0 obj[225 0 R]endobj224 0 obj<</Filter/FlateDecode/Length 327>>stream
+H‰\’Ûjƒ@†ï}Š¹L.‚‡xh@„Ä&àEÔöÌî˜
+u]VsáÛwÝ_Rè‚ÊÇÌÿÏ8³~Y=Wª›È7ƒ¨y¢¶SÒð8Ü`ºò­S^‘ìÄ´’{‹¾ÑžoÅõ<NÜWª¼<'ÿÃÇÉÌ´9ÊáÊ[Ï3’M§n´ù*ë-ùõ]ëîYMPQäÖ½4úµé™|'ÛUÒÆ»iÞYÍ_Æç¬™"Ç!šƒäQ7‚M£nìå=å{
+•üVÙµßqé{›QP,Žö+E ƒ"P
+ŠA'ÐÁQ|p¯t%ÐÙ#èRTH. x¦è%M@	žé¨­.g\2ô™Á%ÛƒB*dø¿2t–¹
+ñ©Ä\ÎnŒë¼–Ú½Óc[ânŒ]”»nCËn:Åû£MVµ<Þ¯  Û)¦:
+endstreamendobj225 0 obj<</BaseFont/CRRRRP+ProximaNova-Bold/CIDSystemInfo 226 0 R/DW 1000/FontDescriptor 227 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj226 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj227 0 obj<</Ascent 1079/CIDSet 228 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 229 0 R/FontName/CRRRRP+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj228 0 obj<</Filter/FlateDecode/Length 27>>stream
+H‰šÀ°J€˜[&>b$€ À ½
+endstreamendobj229 0 obj<</Filter/FlateDecode/Length 1553/Subtype/CIDFontType0C>>stream
+H‰d•}PeÇwÙÛÛ^ÎEvÙóeq÷B$Ð#&n2›„hßÄÀxº.;á¼ƒÒË,c2E|Ò”79íˆw"|ÉÁÔ)ËL£Èò­¡Ñü-ýÎ©=éŸžýk÷yæóû=ŸïóÌ’„&€ IrbB²:’"“JleÖU9‹mÎœ/ØŠÌþ¹hETB*u’2…T‚5Š¤|‚O¢iþû4¢éÕ…Âò@ØëuÓB´Iº0‚&I-ûÒ2s¼Ù–k™g¶;¬Žò›½¼Äš_à0dD¼š1Ý°(§¤Ðb]e+.µGb¢£cgâ‹Š•J,¥–§Å<Ó87eY¹ÝbxÚ`¶äý¯?uPÄx‚#‚	=!óˆùÄrâ"›XIXˆ¢°vb5QB85=Aú×ë	½ºgbA”UÄer¹ŽÜF#ï¬è¢¦PÉT>uˆúI3[³^3@ëèÈ‚§ÆêÈ3àm¢”Ø§„±!¼sˆózÇêÁ«eqû§8epd„AL£Z`XÀ¸Ÿ0R yâ!âb!“1Å„q')‘zÌŒŠÌ¿	ØzãæÖ(”XC­sÌè"!¦Rp[?fÄñæaþ MûÊöÇJRžW«)aF)zÂF^îú “¾Œ¡3#¬qó¥+3è®ŽÄcýÅKgÍž‹0SFÃ^ªu‚AÐ\¥‹ƒ[Ê_T^×ƒ4A±J¦1¸ÇK£Î£Ä@µüï4ûkŒúdA Ù Óà#µÙ³'„œ®sö+"¤S!–š ³0jjê1ˆxÐ}{ÖÛÑ$¯cÂ—D’,{šó%èƒsÑ
+Gº¸ ©ñ›.oÿ÷7Zç,Ø"³øÞCg ”³ßDè}#Ãú]÷ª†Õï[û…ŒîÁòs"L¹ý-ÄÈÊ2õ%3óssfZë÷¯–Xx¶fâ$?‰Û86·+	zØ>f¤Ñ¤å=¸Ð·)ÛýoPußH³ûÝÃñßAØÕ‘;\C*ðüZÅ¡‡¯ÃÛ1`ÎœÒ—“¤n}ÄÛ½÷sñt[á
+9‘9Z˜¼oø|t.Ò2ßƒÄµ—/¯?Ú,ñŽt†ïG46ç«ërÅôÜÞOz½Ÿ®³ÕÊì97Ðá£Ð¢
+‹s©õ&ÀZVëíóï6ßgz,©û“EŒŽÄ?8ö7#°'út‘øµ‹ýähMáš,ÇJ1!ýøÐÕÞãç?ëpÖÉìa÷(h†ïú¡8&Aòw›`£€F "àÉê:z¤”éUEËË³DþÖ¬}§Þ–j!f:&ñwñÉ0¤Ñ Ãfˆ®6-ÎÜ,ã[Úî­-'/‰l­Sq¹®¹¸^ˆBYÕ4ªæÒ'´µ´´µY[rr¬99‡­^™ÿý´¯OP\Èû\û0ÒAà)Höo’÷GzJEq£á@sê¼¢²:”z¸Î\Oûò‰ç’,yEqÐ žá;àæPíÑƒ½â‡‰2v0,Æ¨„Ga\…«Ñågð;U:
+Î3µÇêÛÄêïoÚ&ÃxfÉëJ«Ì:ó°›\÷møêéQ¯à3ÀRµƒBFßÛU&_83:¤êž©‘S«,U“6ìî<9PRtHêý™>’1ÿà,ù_|™{®¡7äŠ6·uòªÕeË–$47H,&ªÙJ0PÜ/j¨vXãú[ªwï•yý&½aCù†2ÑöF}ƒÅ·šÕÄ'ÎFê2nax{lwæˆÄžzp@ÎõŸ™2ÕŒ_¦ê/3¶5fû
+1µ î¬ÈãMfFïÒ¿.hõ¨G¯l1ÃnÄ4 MÎ±§]Ü;JoïÄ¥ïy·¦é½]âÐ§?n½.åäDœ¢EGƒC´æ{³<—^í^óÖk¢ûõÍ[*Ôë¸«Ld˜¨®¯…lO^{»ÇÓÞžçÉÎÎËË–Xÿÿâ1EÖ…÷‡h³¸7w*®;îV¦F‹ÎšêŒTkŠ­®þG÷h¥îqÏc Ü3°e·NújÝ8Ø¬ìþ`  Q
+endstreamendobj230 0 obj<</Filter/FlateDecode/Length 8073>>stream
+H‰lWIŽ$É¼ç+òãûrÕÐIô€‚4:T˜ÑÿÙB¬ž4ÐŒô »“4£ñ§¿ýüüé¯?§çŸþüóó‘®×ÿ÷úÌÏß~yüô—¤ç/ÿ{”Õžûù*³?ûîWYÏßþõø÷ã×GzŽ\i¯¾¯…%aâç>ÿ‡y8ì}Úá¯üLø—Ÿ#]­beïõª¹•çÇ·ùö(×XOŸz¥Yž¯t¥ºŸõjEFÞÆèFóù…{šs®g»òÈÏW¾*Ö‡Qp……aÂq­Ïøª^]îüÂX9ËcÃOíJ‹ërÛ4ÊœÏr­óøÇãçã?4ö•öÆâ›ŸØ5µvÌví
+ëÚ	Ñ¼&ï±®žü¥ÒÌe>§núš×À=&®6^ëî–i8\×\pØ¯ŽwØCçžpþñØWºîBn6L†bÃímd-“‘¯Òø‹¾IWÕ7	Næ²´-~Á*l±´6_ñÁ	â2ðâã1‘³‰U`ÀŸ/Úu÷‚P3ß5|§Ÿ“¶ŸÍÏ+m‡ùyÌWÆßVñ"}yþÊñï_ÊkvT~é!F¼ïêz•|¥ÞT_¯R`<òaç‚‹®Zn+ãà¼ö±ãÏçûEu.í¦àV©ýÛb‰øéó÷e„e×ñ}öùñ°éÿ?ÃòÁì!é5xÇgüùv¿@"‰àÏ÷¸žÄo‡³rŠü…£¬2¾Ö¼^û«vÕyL„sìã(oóñ°{}s²Xì£ ¾p{
+ƒç÷þñ‚ÇõùâÅ}?yúÝm?”ï4EuÐˆO¹Zj±O0Ô)ˆ¼^£P{SQ!r
+‹¼¯©ºù]™yM€‹|t—ôHÈE—¯LÚÕ¶³j‡1D©ÒFjŠÿTƒ¹˜‹Fgm §cï0QÞŸ#Âvê"ÚAD6™"‡”î®«±8ŠÝÉšàa%?ãFuü`ƒ†zbeq9òƒMPÛl»'qTš²Ò+­¼!Cu^}ˆ6ƒU*#šxàüvUTÍ»mž™ÂÈ•Å½²î¿ŸvØ$–$
+e±üÉè0Z;‚¸ÅJLë³NáDFÛã½1@ÚÕ$­HÙ+6Ë_`mØ=ª“i®¼Ú¦Þ¦ ZŠ¸§ßS&!54£ÞúUÒÿµ¸1lt±·ª²ç“xÝ&$Õ`Ä(¼sN‚¶£QVwåÅÊ©[]aWGŒö»¶qF{’\ˆQnýÚEŸŠ“—‡  ¼Ö®"µáŠeÿÒº>³ ÑøÛPÑ§œßFËGëDì.Ç#òK²>N#À&]•·è82Îˆ‘œ°keºˆ$›‘L|4ït£÷)ˆÖ¤9«*‚Èoˆ€*:MRÈVÇsˆíƒ‰fu«N™+PÍ@KWêéÎÇw¥¾K‹œôÃÛ¸æ.NNS“¤ù€‘×É Õ@wŠöªìó^Bàd-wòñJ…›&ygâ
+|NÔ8Pºb_;ˆ¢±ÿ¦iñÑyã^n£¨/i¡M±œèwÛb¡*žÇaîŸ&œÀ yalÝäyðû&Æ'ïØXî¥DÆ×¥*bLVwÙš¬ì<­”“Q:¯ Y÷Ë„LYX›óBB}ñ4†¯)Œ8{	Êds…ÔÝ­"óIð¡Âû“Yºƒ‚8[·
+,©uÞV0‹Ãƒ–›LZzŸÒ™)EÉƒËD­×åÏØáÚÜË`P-QA†ý
+tÄ—(R2¸ æHÈ¨Xèç×,n|‘ñ"ÉÑfà‚ò±WWËRµ»rOƒ=¢Ï™íOÆdø–©žß"²Ä¾»2sªB¢âH”R•¦ ÔvZÜÌ.õ„>÷:]ò03Û7·èMI¦?‰•`VkÌÚú–QDxq þ½zX®@ÇIbT5N%¿kEF·×´*®äàÐcÈvÓÚ.À°íVêwÍö£ÍÓ3‡ŒS?¼`ó¬¶ÛÒðÂqŠmÃµG&~¬o	Ãï÷ùËŽújBóãôŒfŠEF¦Òfx«¢ú{™ŽiûcQoHfMë»¸&³³"É&«‰íš[džÀä<‡Y– šöA»rÐ­d«‹±8O­ßÐ“~TU§YxL‹„ÚöÍJ%Fâ`Ë–<tù#
+n¾0Ÿ6!¯Çô%XôÚÞUJ\­[P2{ò»ù“¡ÖJ›â÷¢hüPRsTßjwlEtÂP4íº{Z¼†^êa0õM¢4¨CÙŒ²1è¾…Ib¡L²…nTˆæeJ‘ôQ<f–-) ‘a¬¥ÚLúeIð³ÇÝå8QFR¢Þ½ªslw™R)vŽ¹‘Ç¨ƒrŠzî“}*ú6æƒE»qcË–<!hGç¹Ör¯Êãl‘çu7(2–J3Â£wŒ/¬-ÁÚ.ë¹n¶#íÚz~Áx9u(<f¡YˆYæ®‘bhÆ›	¶›×¨#fŠýJuHŒÇ€ÌŒ}4E»˜z¡.ÞnãeÝ¯•a‹üÝëž\( âòV¹š‡Ê=^¸kÂjìjEã¢ŽšVw³¯GQ::w‹5¦ˆ‘cÂ}‰`V¶Ì~,.3ðæáÑÜ¬\–â5O‚½™«U)E§cänª´®&P•Fêb²ct…5j°cÜ"Ú›»0»˜ÔÓ=Ûì~Ô#Q\ŽÁ…b7
+hÂSÎ1ÔWÝå?¡…üÝç1Ï¬lhó5éê;„ÿÐ"ÂO0R 4”-_è»x ,ù–g‡¶uW—…`—ÆûuÜ–Ü.pLÏ•¬¶{òa¥[U’rXÃRB%iâWäutCOÉoóVgæÄ]­„ VM¤!ªÝæ€n6nÓSŽÓs8Þ&Ëû“æNwNP¿™a&¶Ã¸Ñj3¤¹¿ºÕÓÐ,RÖðÜœÜfõì	!ÇyÝ(„ ^…º[·æ-§µO&¸e‡Þ$¿]n5h'¬z¾åšñ(i½˜°(D(©ÌÄ&IÉðyY•ì.¤Ÿ—N´êÓÄó‡}m”It{&i#´fOèFµƒ¸Ñ†0ê¾Ñc3x#=ëhÖ£CrŠƒÿêòÆÈFÕ÷âYŠŸš‡,ú3¨®pòd£—r.šdÙÂ Ì³î.gû0Tî8¶¹ÎÎÂFÞ‘-7wîež\rñSà+ò‘c!rÓîÄš7%rd”E<Þ@
+Z1Vâ &6óš„:ýñànî‡êxs€.ù‡ÚºÑ3\÷ñ³Ùë‰Ü2R=˜`$ðKÄéžöLT¦ŸË:Ð³ŒËÄýÞ úæW#»©ºwSõí@ÅòBÆŠž¤´€Ÿ<œOÔjáÐUr˜M³œã"Ëç”9G
+/@/GÓþ¯A÷lemÏæ%=f‡žÎT€nS³aèÞYmÎíñà8jµâ¨a‚ëš%6oxw1‹¬˜I¢ý» îÞìˆ)×ÎÃ×áFvõöËUïpúŒ¯Èæ}Ð0mœá{ñ.Y˜Lª •Ö›u5g:ŠkT'Ïí#v¡ØÄSÌ°„	ÐsQ¾%ÒáALï]ÈÀ“¬HR–úî‡>±@ì´×CÀJtLfÈ®1ÂF!´3Íšxpá1HI})Eûšý^–|Ÿ«²×)Cé ÓŠ©5xçÝ¦9jdË<êB£.%W-äãŠ'ƒÿÓ^m»qGô}¿bÉ K÷ý,Å$€l#0dj)1ZqeŠ
+’¿OSÕ=C­lØò qj¶§/Õu.eŽQ³¡U‡DQu„l5°‘©eV“¨Éšæop3<gÉ Wõk
+ÔØbÓ)AèDf5JçTh¬bí\[S¤x£ä:zV-+NêÍô–^¸¨õŸ6q`ƒ0âA]ë, –U.2“ú„¸($TžrühXV\_sèú$ó©C9ú3ÇäS(5†ek[§‡žÞÆÀSÞ¦ÅQó1úJµ†D[«aZkIQÕ¾Õ…¡Ð„¡p¬7O#Vhžvôi&›WYBðUƒÊ2~ÉÍ¶ ˜\xŸà/½YË¨Í R‡F”‚¡»å£J¯=Ø}hÆ´ûPiQNS&„~ `H—{ÕAycraàÔ/q{A8Ö	9:ÕÚgz4 ¬×’-<p/%âcX³uùBí†Š¡ÝŒ¹=ÉÙ+:ZÝ¾v VªG• Ç*—/óGNŒã#ëÑ	Gdv}ÞêóH´Fú™Žf¯¨/´“Åz0èjÕº+#m/â^Žš¡XY&ƒÚ‚€$¯=äÞX~öMdâtÅ9ùCÝJwmã0Dím˜óžvFÒ±—ò ^ë”._ÌâÜÈSNM=Xˆ —´ºRÛì>hCÕ…5µú- “é³Tá¡xÏÓI±:ó>ê >O«ði”Sþ?ŒTØ©þ‹Œ”ÿ	#Õ~½‘Š?o¤žúû_@èá×ú¤óÿÕ¦åMCé'êù”øŒ<·öË÷Õ~¡¼Ý¬óÙ~a¾­ýN7ö+ç­ýrÏýWª–ÒjÀØg¬çœç_˜dfkÀjØ°¾u`-mXŽyãÀR[î`ëÀJY-Xr[VÓÖƒ	e­¬·Õƒ±—\=„yãÁªëÖúÆƒ•¾z0³‰_ô`)¤gL]’y°’6¬oL˜~½š0ÙëjÂz~fÂš_MXˆ–ãÖƒÕ2=Åaz°Òžy0ìiz°ê7Leiz°7,ÕÕ„Ám<XÒžòs†u×ÊóÎ*Ý½8 i²µ_ßì¾zé¾æsËán'~
+Dœ!¹u9¼ÞýÖ‰q®dçª“Aâ7	¢“†Nâ?H,a‘÷ÕÛXù[‹ŽñRQ/^nþ:¼ÿÝáŸB«¢Ëá÷X%}­³c–âìË¤£ù·à‹o»¯çO·oÿöáûÃñßOß¼¾Zþò­ž+P‚×ÿq¶ƒÇÙp4Y‰/XÂ!…/bïáEeïwW_/OËùn¹=¿ÿp~8><}Äã÷Ç×Ëµmö&c·WOç7Ç§·ÇÇåé¼Ü>_=	—O÷?~:.§óù¿8üfwõêáõrw<ž03Æ|ûxüxüøêñöíòÃ£üxÃ©/®D¶íuÛÁqÛò'5±|°A@
+ÐÊ¶¿»’"[×^Žsu>ŸÞÝ?]ÿãð§~d3K@ÒHiG)Ž*u›“ðgo‘ÍÖþx{~°3‘àÌß]ýùZ
+÷êüæüôŸG[„ÄÅ”¼<ŸÎŸ?Î‚~t¸nn¹’î^ÝÎá‚cþþâÕí»ë ä¶\½y<zx=Æ¥¤m/Åy%w‚$þë|o3I-ü(C‹¤¶¥å~ÃŽRÃÇãîïËÃefW¡nEcJ=t/´1…^p)ÄáaÂæ%„8Ê{¦60Wkóêr-BÚUÀsZ ÂNók¡L‹Ç„äBS[‰VYª*ï%úz%ºÐàê-¸ÕTáñ$Žõ`%ßhxÚåñXn¼ÓÀ9˜ïÕ{çÐi\­Œ±nÓ9:E©«R5q(FEXUî²6’M+¦c’h¯m‘ÈùWâÜŠRzÃ¯gƒ0„‰Æö¢cË'‘cù¥ðO~Ô½Êšµ@àSGGx £•‚¥
+×*Äìº{Ôž¥"Di(í·h¦GT!Ø£H&¨ìa„´ktÑÞ7ó±nóü¹£”æEÄ[Œ@mcÔÊ`yv5šÞiJÄ¡…6{D:}ÇˆõÏi}Ñ™Â1OtT![Á"Ô‹=ŠzPw-Ôémt^êBþ²H7§S8k÷1°)µ?ïçôU>ÑîÛ1‚b	÷Q<{‰£ì÷ØKO[ðµþ9ášÚˆ*ë×æ±@W¡ƒÐ–:P UèŽ–ÄôE'² »×Õí6«»³ótœè³³ª¾–à¸HDv/6$[FøènSUÈ'Á5§,Xséyó†RÆu0Œl„RîÐC6üâàRj`›iƒc!»¶j´Ið$¢hé"Ó‘þXeR™Œ“Á'ô­ÁYÂÏœçiÞÑÍÕJ|¡“ž>›;”E š§´ØƒFQ; IN¸x±÷EÊÐòèå_¶8;Ú¥=×ôžŒÑ@Œ2u)}¦ñ‡WûÈV´°sñ Lc„qB®ñ!8°zXº»‹A£W–Í×mB"JUè°dH8\ ÃÃ2G´‰89X¿Äumiÿ:‰³ÜÛéår,c"°ÁÁ_Æ˜2­¡nµGrµŸ‘•úÀ&¤1÷–g…Ùä È#å­F$¯—0®BÊÄƒš´Ì‰Ê%üÔõAó!öE€=²•À¥¢=ÔS:e¦’Î­Ö¥Ï U	ù-Í8ËÏÑëË^Yë¸µFê†T{m…ýSÜ”q
+Íî;µb8A„þC°ŽÍ¨úQ?Ñ7·Î+z‚¾Ú3Z&îÕ{t»]ûµ.%%Ûwì­ª7ÑÙ+Ò4´zc:î¿ËE/\ÚÐŒBU «?U°/j…:+·)pí¸&Ô-ÇUÙ€l´dóÙ!´ød‘m+ŒzdÏZ£V£^Y´Ø®	šÒ¸¤5ŒËh)s¡¢4‚aV%±CÍžá´aÇ™‰5ÑÔ\ˆq JJD+L)=nâ=C¨}ñ3R°éPÄF$$°fÉ\WàRXöjþ°ØŠ:ÑðÍÝ+KÛÑÎ8w—¤¡ËZ¸§Ý N”é"q°*T¶ñ‘dd¿ÒöFÓäýý¨Sf‰´:Fï§ì˜Y‹Då^Ã‹ŽZA)2Ž~\ÿ¤OýB±EY±ù’ã¯1‘‚:}¢F“‰°—ˆm&2æM+âèe aa‰u†V˜°“9˜I¼T**,1ÚN÷†ûNZ,$•‡¡a5l"’zÑ&·hMc¸üP»æ½™˜ád
+oÙøf ÞÄpÞä SÌ!ãò,ä©[^_ŒT£â#/:/“°3°ÜØ`AßÔ@ÇN©¼ƒªnÌBtžâKrG G cPgÄQ”¡• L_¾ÈûU>«rr•r89åÊûR>(Ù´q³Vê³0rRJãÅ
+6àÿ‘#-¨‰a©3ÖYOd‹PÚ^O^Q×J¹x	Î;`U_Ö[wÔ]5—Šùi‹,ÇvS5-{¯ŽA&R ß¶P*Çq–`äõÂþg”Ì&ù$£7ŠêJœÉ„RàºZUxãNoç%<CrÝdŒuP ™F`Ùóø‰]I‡bV°¡Þ,FAWæÈ»2©J±ËêOQ›WÅ,Ñ$
+ƒÄÊ#Jþ“f …ž¦i˜¨ÐV«„ÚtmˆÐ†/*½F2h¶Áˆ•
+‡›@ï
+[/nÂ««-ððzËPÚäÅÔç.Ã€%¨ú[Tq±VBŠÀ÷*óœ,’õfÆEÏ¤$©Är»ÓK¦~ù!¥ÌÉþõ™ûNláV¤Þ´-´¾iª#Œ¸rT™=Æ±* Ç2}ˆD­÷Q
+æÒ•0 LLj4ÑRë!Í#íæjËxÎuŒ’äÒ­i¤¢p®Q¨LM£àÓPª«Yt#&ÿ¥½Üšã&‚(ü®_¡*^ì*6H#Fó;6×@–{Q”q¬íà„\øõôéÓ=Å
+ ÊqË»š™žÓ§¿&5ÂPÕGºý=:5ÂûW¥oßÊ’oàP7”Ç„8 c@L’¦y2ú€ÿzSµGBÛ¡õ#(,,H•àMâh#ÈšõÊH],YÇÑæöÝ·ˆå‚ï6[šb²i&;"TÞ@zìÚÁ@­½'ÌÏ/á@MIÃ@!LGxÓò6¶®ËHí9„å¯’§ÀN‹í°;qEíšù{OÌVä;M:*$eÔ‰Ÿ¦“ÚQÐ³·q8°2˜j$SÔ¹ÿ~Ú˜ÓQ¿1Ç%˜cÁ„ÓÆ`ŠßÛyè#¦­èil+¸ÒC³œ'“ýI•k§×¬”æ!ÒãU%5dùØNk½¶¶¡ôlÔRÕñÊ!÷V¶î7Y ­9+ÒÜ².`ìÇvÉ9FTëIavrØÐÑ6>e*®´µyk±m¸±Ó,}iRè;‚›f—ˆ$3aDù¡ì=¢Œ)sÄtoÿ¦Ã—¾¶Un”´?v!u³N³¨»·îÂŽÂ'ËÛ¹Qc¹÷¬HÖ‚@ÎÌy-æ–k‹
+øù_9Óê8‘ØòrÝt4Z
+dÛ«Ãú($‹-N†VaÂDäó{[ÔõõíY|£Ÿ¨o:}’«T™E~aâåì!î`ñ†./‘ªˆ@,ïqòç()¥™ó`1· ú–fz»R5n®‡«Ó‘6ªª!ðq!Ç´¹àmŒŒjüÃÚ¢i˜x—–-äf±’Zôº±
+7Ó‹<2bQi‹þW{¥tn 4Âòƒ?©KË&ô	À¸Ý:åïUHÊ°J³=tÖˆÆ MU‡öLòÛ¤ši?¯ÃøE#{G¹š	¦ëDÖ¤ !z;PLÔ²õ Ð>]Ž–Ã)oJæ“ 9ö-‚,HÐ—‹pð6H-ð2±Àrô¬€ï÷ƒ®tG¼]¹>m»x©ªgj½uÈ=)Ú¦1µÁ£0eè-ê ¬±Qœ5ò‡;›'Ø¥ä^ò­¤+‡‘w3bŽÀŸ9NšXY3˜dœ[+a®YÚ!hÎop¬€RÉµ1'ßj–Ñµeh”LôÕiB"ä;âó…0#	\ÍÉºH‹ ð`Êr™Œ‘PNêž˜8æ'‰²Ò±S}ÒyŠµåk1:ml„°˜¾±QP¼Âª¥™Y#î³Âjˆ©Ð¿17wÜ{ÝÔ)ŸqõÀš,~€’X™¾aÑ¹$G †%MÊæ£ð?±†]c(hS¤#ÍÈ8ÛÜQÕ‹;­1ÑH°¦<Y`AMBRæães
+˜5{š(MäP°}dÃ›¥¨šJtÚ[l (/š¡:=¦'„€íˆ‘¤RLGh!*,Ú¢º9¾(3Ž£%]»“O¨Ñ]LP¦cmd›b+³:„Å»*îû¹Š¹X‰­&•7ÍKêª¸‚t¶äØn‚•·r‚7mR0V´#æ:F ÔU‘šŠEmî¼ñú ïZêcRzWˆ7¦·JT'‘TëXåYp2§ÌlyOA7©†‘ò`W°’wñF	1ÐZ•ÓS?ÇÒïåZCOwDNIVÌÕ«çR'cvÉ”bŸ­Õp·ü=¨ãòáVZ¦ŒJ˜HßDçjè®N‡"WU­Ú³Ñ™î0Ö"-ˆ´ž#‹£„ndñÎcü“úPåìš'àÈ‘yS-±]ãM ½ÙÄ^Sf)vÓŽµ6Ú±£Yñ°‹ YÆirÈû;­
+œÒœœ)ÐêDŠ]Êú”¿{Âñkü4¦×hOt'xMpªrr0Ž«.äJ1L²ÙQÊiŒR:CW1ƒë¾”sÒLèÔ6Ð^U :_èôgVB"0k
+“ˆJšó­»†ž¯yz5²¾¢~ñF\*@¨‡bÆÈ§ "?§1•‚£I©Æúy(Û·UˆºCÖCŸ=€Š5¤bw]3Cjº3|"|¼‘Ö$Ÿ‰‚æ×£ØX¡X_±Øt#[ÁX¨`l¨`,ý0Öÿ+ëÇàãÁ}þ¬Ä+ŸoõùðÏ}^‰oª‰/¿•ø¦¿%>l,/Ž‰ÃÒÍZk”Ã°è(ÕwEþÊi|-Êñ…5Ê¡z”CýV(Ç¡ÌQŽØTP.¥
+å°Ãå‚F†riªPnè—¢]¤ °¥B¹qêW(7†¡F9èªB9ÜÊ
+å §åòT£Ü€Ã×(‡né(7†¼ œN¶ÊÁ7*”Ód,(G¿7”K]Z¡\ˆó
+åÆ
+åÂ°"¹)5ÉI-8Éi–*’3Ê&É©c:ÈÅ.¯@ÎØ–§Þå§g¬8.å…ã þ…ãà«Ç).;Ç)Ô:Çev/ç85Aç8USá8Š³p\Ó€–H½aUûl:÷›ƒmóÞ¶ÿ¹}Üð°ÛSuUüöRn”þ9µcŠÀbidQÜ&HålÏšïönÞ9:~ÿƒ?úø“»Ÿ~vïþƒÏ÷§voûÅ—_}ýÍ·ûßo?’ƒçŽ´&í~û°Ù;ùñôá£Ç?ýüä—_wgçO»|öü÷/_½þcû‹˜2Öí¸n'Æ-‰‹’¥ ²œ;_÷øâüy»iï]^ì’¿vïÕ“³“öÓ‹'ºæÑV¼¿k'™xÙåê D†—š¯Ús9nî1:fpM{ùS“\êwgƒ6¢,ßáã™+IKŒz:…~	ù,È]µóAåÖƒùÄ/eã{ïÝ>ŽqÐ›ìQ•{Ceê–ŸÞ‡RÚ—m“PwÝuû>°}ë–l³vÙË>§$Q¯ÒŠÄu£ÇúßM7*iÔ\Î*gé²Ú4Î*Ø·æ³ÚC‡=È-×{øN6±/>¹wûøàøZ*zŒ8Iph’/ŒüøáÅÙÙïçOž¿Þ—šÙ{·ÝîKåí]žœ?{zrùèüÔŸß»|òâD¢›+z¯V§F“Ž2þõéÄë:QÀ #J3þ¿y†û„åA+¹Þ`q›Å$Öwæ£ÿI‹W7up%+®»õ¦Vº;º{Ø6
+0 2;p‰
+endstreamendobj231 0 obj[233 0 R]endobj232 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj233 0 obj<</BaseFont/TLURPM+ProximaNova-Bold/CIDSystemInfo 234 0 R/DW 1000/FontDescriptor 235 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj234 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj235 0 obj<</Ascent 1079/CIDSet 236 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 237 0 R/FontName/TLURPM+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj236 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj237 0 obj<</Filter/FlateDecode/Length 1408/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»¢ƒ3[ŠˆY4B|4
+j­ZåáDÖ]`ËcWÀ]ðµÆª5%ý!Šø ªE^²Z( RªÖ€Ö4¶ÆŠB©ÄªHC£õÞ5ílMú§ß¿ûÝ›sÏ¹çæ’„Ê‡ IÒ?aybÜª¡«rmÖìÔ•6Gê´¶,³7!r@‘F”'‘²V%‹GçQ¨j_÷ÐªvM ¬ñ…ý~°K39€®Ö4IªÙ%	æ³ÍdYj¶ää[óÚì…¹ÖôŒ|CRÈ–¤©†©¹™†xk¶-'Ï–f˜nˆÉÊ2ü[”gÈµäYrs¸qq|B¡Ýb˜i0[ÒþÇOy1Žà-¡'–Ëˆ5ÄF"…ØLXˆ"“°[‰\Â¡j£Ò[«%´Š^b2BäÅD/9ž'“ÉCäkŸŸ&ŸçI- NSTAªÕ¡ŒéU£Uä­jh¨¡äÈéºÑ>|ñ¦;U:l­€5‹'Ù?]ÀÉK#ë Ja2U:Œþc â ¢!:¢1ã£0£E9T¾é¡a¡éCà¾õÏ†žÕ‡¡¯ÈÊ£F'	›à
+†õ£FÇ`¦?ˆ iOÃ>,?yžÒM‚ JnÑƒV3°¸§€z"L@ºÃC¬ÑËÄÓè+Í×ªî
+ßuæ¬ž=w1žÇd	U{¿Ì"øA5pENžC OÞ®q ü"å\ÇàiO$*¸ƒ"¥*ŒUóO ªi¾%y)0{9¾12l¦w
+í
+÷jåÿh§.©µ»ð¶ “†‚’œ€ž8f™)uy²µâÜV‘…9EŽ¼HÜÑ¥¼]^¨‡c£F£Ô¼—{Žá
+ù˜7‚â7Fš=çˆù‚ú_p5 …Dàùr¾n2 7¡ÏüùykW‰­Qô¥†Ö3ß=™¤XærfÜÙ„y&¤%¾‰Çkïu_­¸\+òùë¾ÞQÙ[v™„õ¦óÍ-_¶7|µËV&±·]@@ÐíTú‡ UúõªÕâçL›%ñ\œ€¾¡8Ãù»Økç¯\ù+½ÈªÌm›ò7×_íëo¿zçëæüÌr‰½èÕÀ«/(Ž‡	°|ù—5p@‡F B`ÊÝ»åÍmbüC:;kMá&>{CÇO%ÀJ5Ì˜
+‰üKœ„4$8aºþš•É‡%Ü«n=Zwý¾À–9d§ó±“k‡0””1(¾tèëê­u©¦kjêEkƒÄ?éñtèd'ò'Ã¾µ´x
+â¼"y¯¥7(n$hNIÀF«Y>¡‡§ÌÓuß¿ÿá*KZ–Èßëö ÏðÍðs¡ìre»ðíÅüX	›Öä†›ÏI·²ä³€¥ÊºuIlýL¼{k4H•Ï*•‹-ÅU+«Nµ\ïÊÍº ¶ÿF_JZV9[@~Ñ¢9È¼röíºö4º¬³·$|¼°¶6Cd1VñÈèµ@qsì°Í¥ë¬+9uFâÝö!zß¾Â}‚mGE•9Ã@MÅ9ÿ¹Hõâ†·G¶&Šì–9ç
+…Þ¡(z°—±m3Û7‰å?HÐ‚<1ÓÚWÿuÿZ½[Y¡‚•{ ×åéäöËå¼½Wëx÷g¥5O
+}‡z¾¨Nùº?NR#‡ƒÈÁ jXçÙ]h¢·º¶íýDpm?|d¤’=E^(êÊºwZS“ÛÝÔ”æNIIKKYï%#KšàÎ º™Û}Bvï:þ²T¥jt”–gÄ²¨È’’¿5ïiÆºÇ€~¬»ëÈ)ô%š÷à¨V>©ûG€ pá¸>
+endstreamendobj238 0 obj<</Filter/FlateDecode/Length 4320>>stream
+H‰lWIŠ-ÉÜ¿Sä^vÌÃV-ÐJ¡…PhXTZº?È¬ê¿ÒóEz„fnñÃ_~¼~øóéúÃ¼^éÞy]ø¿×+_ÿý×ë‡?ý-]ÿúß«¬víë]f¿úîwY×ÿñúçëçWºF®´Wß÷Â’0ñóß¯ÿÀaž{Ÿvøó+_	ÿò5ÒÝjiWïõ®¹•ëã§ùéUîíÒõùªwšåz§;Õ}Õ»y7£wmÌë7þÂœs]íÎ#_ï|W¬£à Ã„ãZ¯øªÞ]îüÂX9ËcãÂv§Å…¹ó¹Ìy•{Ç8?_ÿ¦±ï´7Bð¶>±ijí˜íÞÖ½’yO†±îžÜœ¤ÒÌe^S¾ç=ÆDd8êÀ‰±n!´L«Àáºç‚Ã~w¼Ã>ö„÷×¾+ˆ P›“©ØðûYËdä»4þRôªo¼"Íeiß‰ä`YØ–‹ó½‘œ»¢nxóñš¨ÚDÎ*Ž0àláy1ÖàRÍ2L|Öðòpí^rÁ³ùùãõf§­0?ùÎøÛ*^¤oÏÿF;þõ[{ÍÎ.B{Uä	ºë]òºûë]
+ê‹G>ì\èªå±2ŽÍ°>¿^TÓn
+¢bJíß[ÄOŸ/¼/#,»ŽïÃ°Ï—Mÿÿ–fIÿx¬û¥?M¡ù
+I~½€ëIüv8«§Éß8Ê‚¿o=¯×þÃ¶]uéû8
+ÃÛ|¼lÆ1>‰–Í—}48nOaðüÞ?^ð¸>_¼xâ“§_Eû¡z ‘0ª€F~ÊÝR‹}‚¡NCä½ðz”«75õ7Â!§¤MšZ"`0ß™…M Ñu`ò# E_;¶Uq6À¹*2qX¦)üSç
+dÊèl uì&ú›û Å„vê"ÞA6™¢‡”Ê9áºÛäÑ‹ýÙœ bÕ?#&œë×6¨¨'6×>¿±	ëb»€q`÷$žJSVb¦•#£uÞ}ˆ8
+6ƒU*™#ñÈäî*¶ftHš?„‘+û{ee \`ÿÿA¾Éâ´µ6YFk9,yO™}©GëVd´=¾vP=7˜¯¨Ú;6Ë_`mØsª“mî¼ÚoL:_¦ ƒ ÁúKvÊd%Vª·~×ÿÞŒmÒEa» ãvÖ Í§
+I-£XØ‡‘9 ¡0èœÄ÷NGYÝM–»§²”è¸Âœ
+aIÚ_ý³tš“¬Àn¬§çú½›=×/E¨´µ«Sm¸m9Æ´®Ï,T4þ6[=åüe”±¼p´NÜîr<6u26^I4r¶éwn¤ãÔ8r1£aöËt?P6£ øhFÉ9‡¶ñ‚„AÓ€’ñòmhè•-Ñ1%4ùœeû`±ÙâHÖ‘rf»ÊOwÀÝV.ÇÆ®Äã"s€àlÜs—§iRÒŒŠÀÈë”`³ÊRÑV•SÐKžL°åNZf®„DÆKî™·šÆ¬Px}í ŠÆœ¦H'qöòE³ImŠèð+Ÿ¶ˆ¨VJ€qæ~ðiÆ	šÂÖ}:–É~Â0>`c·—Õ\—ª¸Q1 YMM\vªV¹gµ)¾Í†Î(¨ºÒ°6×¤šå©\¡@ÙÛ8P››£šü¤¶\ÛC…Ï'³tFGâlÝBT ¤Üù²‚X|ž³<djÈÒ;»UIÑAòàÑôuç3uˆºõƒõUdØï F|‰þìÒ­¹àÖè6ê<7Â
+Œ?Ü­X¶±>;Ý-ÆCÒ;ïS×`Àpôì©^‡æÜ®?å’áS=¿E^û­zf=æTAe‘ð¤:*M)PŠ¾áfvÉ§`ó¹×™’‡–·ÖîMÇV't’*Q¬¹0~Ÿ±'ämBdH.Ô)–Û/ÍæÊRK?-°Vt{Q«"êîÍCØYÛý¶ýJÿ®Ù~kCõôÌ{†:â÷^ptVÛm©¼Pqf•ƒ,üP?&RŒ Ú3ÔÙÞãŠÄÙø–G•ä2Š&ŒL­íü2­¿ê¸a4no¨fMë‰MæåêÛFì³]ó|Ì3ð—\èÝ¿A–=Àƒ&…›òvºµlÍ¾§DN ªNN³ì˜–˜Ùæ¤~Jìñ¹…éC÷BÀà¡Sù!“ ôÈ8ù¾}µ)µÊQ$Ì~¨ïaO¦Z+mŠ^<…‚Ã 7$æ¨Žj£Ï]Ú¦vB€êÀlM[êQK#Ì@¦¾I—Ç(«mcÔý&y…"ÉF‘çD×4\%ŽHþ¨.+Ëô@b}‰:×†Î½o¼Ëyj¨.êtÐœc{Ä”Jm°s\yhƒrøŠzîS|êù‘{œ+fÓè['°ã©ìè<×ZžUY÷8[dyÂÓ‰Œ¥ÎL…FsÝ¹+¸`|ãüÖuÁ˜XÏu³Y×ÖõLªãø¨CÝ±Í2Ä"!`î	†Q¼ym±
+Ã¨#.Ôú•Zk *3ö—"ª^èK
+x
+ò0B<ieØâ÷~®.µÖ½õC®æ!+ˆ¼ÏÐ„Õ8ÔŠ.Œ:jZÝ£¾ZMÎHODËZãAvÑ5v>˜j‘yTÞÛ5ø"âÑ|es_Î½cäø.Ø›ÉZ©é~T5‘ªBR“c.,e­ç'ŒpžÃœcOÏÕf£	ãr.½Q=Ÿ©Ï/C“ÕSþãRÈß}óÜõ‚m>¨&_ýâ¿ŒÙ ).HeË7þ.¾–|Å½æámÅê¾ð¤‚âu°xÌë×íöÜ{ØEéQU§§b¤ÙRA%jâWÔutƒOÅ×Ã{šw±†šYXCÇÒZñÄýçÛýµYhL_r\ Có6ÙáŸ4wzª‚ÎL4ñÆƒX›¡ÍýÕ£ †."eoÀÍÍo_÷ƒüœx¨ÆBAãfË@F
+L­}Ò0Á0;DÇ nßT˜>PA;©Õó#Úü‹/“–üKCÁ¤%s=Té#>1;“#Æ¢ôóåÄ‰V¡w‡"b£Ubä³PÉ5‡‚J7:F8DDê¨;""Èf°ÿFÖQ®G	žä%þ«çì.±1êQáÁ>KÓF#Ä4æºï
+/žœöÒÏEWY‡0Àó¬{ZÚ>—'‚‹w>úWëíòð—‘à‰æ›ƒ›.~
+gX‘&‘Ÿv(Ödº)”£¢lãñ&«ÀKÀäfn“\§?îå	èN 7(ÈßUØž'ÆvƒÚø‡H¬]o’à/—›ë_øLV¦ŸËbÐ7·‰§¾`	Nq?žÑÊ	®²aÜ[TÌOÐ}ð$¹üäáz¢WÛ‡î’Ãþ˜œåUžµN=¼îƒû'øì`ß¯,ï9¾¤) xÌu„›š‡à>yà€³Fá…ÔŠÅ9Ã-®›€SŸ9fÚ+€ËÿŒg—ŸnÕ<„:ßï7²£uðàØçó
+‡ŸAùºYÅœ{dLgH8,†’È¤öYi}‘®®ZàâÕ¹IrûÈã'6±ÁúJÆÛŒë«µcèt¸Ó{2ð$'’”C€yb¸Cò3XeŽËjkC|°ÑíÜhM;ˆxR_2Šö5÷½-û>_fïÓ„’Bÿ'½l{Û¶8þÞ@¾_ÊC“J%J@1lÉ2 
+d˜Š½h†B±™X­-yzX–}úÝŸGJL² ö"±O¦x¼ã=üŽ‹
+VWÕpÞ’‹0™IÄ#!ØƒG’Ú…qÆ°DXa8pÔèÜÁaWÙ¦ÈKè¬Ò3:ŸÃ‰¥æ;ƒ ±Bž!·t²ø€éÉ„C*žFæxÈmïdB>e-n¤Ã¾~q :d¦ýÜÊ¡â¢Ó¶›™/*EEéå} K;%xÙW.'Çv<"A*„9uUÌN(Ë\Îp‰÷C‹ž³ìI¥‹cÌ}Ô'T‰¶Q>B¦Dñt+_^íp«™–Š n8Å‘H¹{\zdó“%³¡Í¶BË®ÉA:g?IßÐ|{³áÆòÞËœšû•@TþGW#(½´ô-™B³p'@&Úˆ3ŸîsîçeáfFžáCL¢¶YðaíWnOöÎýeð”Æã·®h\Ñ;-¶XžòDF9^Xßß˜–ìñ$M˜$
+W·˜ œwX°-]ç¹÷^<¥øHR¹8ëù†9ë¯L¢»ÇzÀÈe<q(êGnƒ<¸‰Š{‘ËnH¸{Ú?µÃ<²+)½é6I[,üÜ‚§üÝ;š%~WÛa‘ð,} tGFw®GáE<Ë„LÍ¨žÒBZP<lŸó7ã¹ÁÍM¶|ý¦ÔsãÂü&S¹ËWjåÐVÎûîW¶D§Ïå„n(AÙu“Òósì|™`Oˆ22e‰ãKÁù%T%e0Ç¿,Ç”s°‚ lÖ³ÈcìP˜ùá©c©œ¦ÄÿQúŒR¯Â(`T¹`Tú"EÉÿCQú5å½€r=WóƒÃbþb-/_SËãd®æ€´ü5–}Òz®&ò@Ë…ÏÏ¾’r¯$Ï¾ð%L†„ç[_HvO_Ø/¤/äi@_súÃø¥tÀ_*[øËÎÁÎ™¿`ÿÂ_Lf3iðW™üU¨¿²4øK•áBþÊõ`*	L«À”‰æ	ÌÎ‘¡/¦“ ÀŠ2 °¼\ Ì1â`å`ŠÙi°2 ,W€ÁÀøíÀr /œµÉ˜LþÊTÈ_:Ÿù«àÖäø‹-™ù+ÏþÒIÀ_Ü•fþ*UÀ_J/ øKñ8¹ðWééeÐv¥27Ž_WçQóH•Aôw«·ñgªy±¨nW„R(ÂÚ­Õvõ.&‰Éˆ8Ö1ýI’ÏI.HHc
+%’&™ÄœžëÄ­¥Oóš„¢éü"øŒñüûêTê
+¢ú	ZÔxâëoFN¢TÚ>ä€%P%y.Õ”vúéR«W±.û™ã•Ëjõ¶ê¦Íîãñseþ/·Í(>\±W¤mÞËx¦Jà8†ÎiÕQRV–%‚Ò*ûU;#.ºÃaj›ñáôjM‘u÷¦7[±þ£úÅZy–ÁÌè7S÷›¸lïšÖ¬ág—A*V)c«’>H%]:Õ[r	©ŒÞ·cßm§ÍØtíúvÙ=[$vNSŒ?	Û!qÍÑUo>\3ˆºÝÑ´oÄÖléª÷Í?d[`ìéÅ¸«GÑ›ûºßbãí¿>s¸1ý Öî†˜þ)ºoÆXÔTë„8ê¾®)Ç"Óâ¶ëiSÓôbê;³¦òE÷½¡ÍéÍÍsÅØÑè&ôCÝnÅ±ïý¥»Åëâ¸¯GÚêpæOÉiðûZÅ¤IlzSd-Œ¸›š­Ù“Am-vfõ4îºÞš<°Äí¼žÌ½>aƒ—;¶vF½9bY;ŠnêÅM3â´´#Ö7­¨Å}ýÀlà»vh†¯XAÕŸÓõ	yËÇz3Ú-àÐê»UTno1”¾˜ÍxæÎöF‡¦½sFêþ+]ëf3õdúþÁ^2ÝgßtÓ@—8q†›Æj´§ÅÓ»‰\i®O¶âæ!°æÑ½F‹ÿðµ$qQöŽÓ©Èé† Ï^ÊMà!Q–Í9½¿Ý$võ_†Žó@î0,èvMM!$à{¢ŽþbÎšîÌ%Äå‡±úW€ ï’«A
+endstreamendobj239 0 obj[241 0 R]endobj240 0 obj<</Filter/FlateDecode/Length 236>>stream
+H‰\MjÄ0…÷>…–3‹Áž´Ë`h3-dÑšö Ž­¤†Æ6Š³Èí«8Ã*°á¡÷‰'É¦½´Ágïm‡á²=Ž>ˆsÎÛ|Uå·“IB2Ü­sÆ©Cuòƒ›s¦.öxò’#¾šî²[RúÁ	CZƒÃ½˜ôj&Y°Së¸ïózbæÏñ¹&„ªèóÆF‡s2É„E­¸4ÔÏ\Z`pÿúÕNõƒý6TÜwìVªRšÕýc³«§Â^]Û^níBÄéÊEJ¬-x;ZŠ	˜Úžø` 2Îrp
+endstreamendobj241 0 obj<</BaseFont/BZVOLB+ProximaNova-Regular/CIDSystemInfo 242 0 R/DW 1000/FontDescriptor 243 0 R/Subtype/CIDFontType0/Type/Font/W[0[507]1 2 0 3 4 258 5[125 56]9 10 500 11[250 167 333 598 230]16 17 612 18[339 424 588 557 558 590 591 515 581 591]28 51 598 52 53 612 54[339 424 578 557 558 590 591 515 581 591 658 629 676 700 569 550 713 747 712 239 475 601 510 809 708 765 587 765 608 586 570 700 658 883 652 626 585 527]92 93 575 94[495 575 563]97 98 283 99[574 552]101 102 225 103[514 225 268 808 551 572]109 110 574 111[330 465 294 551 490 734 486 490 551 472 572 554 582 615 509 491 626 642 635 229 422 534 458 719 632 662 522 662 545 504 472 623 572 764 567 547 516]148 169 658 170 171 947 172[629]173 177 676 178[700 728 700]181 197 569 198[550]199 203 713 204 208 747 209[731]210 211 712 212 222 239 223[713 714 475 601]227 230 510 231[529]232 237 708 238 261 765 262[1105 587]264 266 608 267 272 586 273 274 672 275 279 570 280 297 700 298 301 883 302 309 626 310 312 585 313[728 587]315 336 527 337 338 889 339 360 575 361 362 936 363[575]364 368 495 369[644 577 575]372 388 563 389[858 566 835]392 393 509 394[797 509 551]397 399 792 400[835 283]402 406 574 407[554]408 409 552 410 421 225 422[451 450]424 425 225 426 427 514 428 429 225 430[291 307 287]433 434 268 435[293 307 299]438 444 551 445 468 572 469[962 574]471 473 330 474 479 465 480[557 587 283 294 313]485 487 294 488 505 551 506 509 734 510 517 490 518 525 551 526 528 472 529[572 574]531 552 572 553 554 821 555[554]556 560 582 561[615 626 615]564 580 509 581[491 720 949]584 588 626 589 593 642 594[655]595 596 635 597 607 229 608[650 651 422 534]612 614 458 615[472 481]617 622 632 623 646 662 647[953 522]649 651 545 652 657 504 658 659 597 660[1008]661 665 472 666 683 623 684 687 764 688 695 547 696 698 516 699[626 522 226]702 703 0 704[226]705 706 0 707[226 265]709 710 0 711[265 0 305]714 715 0 716[413 0 127]719 720 0 721[236 0 313]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[205 0 194]739 743 0 744[230 658 629 550]748 749 658 750[569 585 712 765 239 601 658 809 708 615 765 712 587 575 570 626 806 652 796]769 770 765 771[589 575 490 572 485 489 551 572 239 514 490]782 783 565 784[490 489 572 582 572 483 572 458 562 691 486 708 771 658 623 766 293 785 725 779 239 626 589 485 551]809 811 239 812 814 562 815[572 771 514]818 819 123 820[390]821 822 143 823[230 658 587 629 550 717]829 830 569 831[909 584]833 834 708 835[601 712 809 712 765 712 587 676 570 626 806 652 723 611 958 986 752 788 587 676 992 608 769 550 676 586]861 862 239 863[475]864 865 1060 866[785 601 626 696 751 909 708 601 658 806 527 575 574 540 436 561]882 883 563 884[708 485]886 887 552 888[514 552 671 552 572 552 574 495 402 490 683 486 552 541 783 798 610 712 522 516 767 547 554 436 516 465]914 916 225 917 918 849 919[554 514 490 544 575 465 574 708 455]928 929 551 930[514 490 552 551 808 541 560 808 816 610 522 767 572 436 561 552 402 768 590 743 561 587 524 587 574 550 436 550 436 606 574 931 733 584 485 614 537 645 559 601 516 913 725 739 561 1024 763 1079 901 885 692 676 495 570 402 626 490 626 490 674 515 889 640 638 550 611 541 611 552 908 692 908 692 239 598 514 729 561 712 552 729 561 611 541 844 680 225 658 527 575 658 527 575 947 889 936 569 563 747 563 747 563 909 708 584 485 584 431 708 552 708 552 765 572 765 572 765 572 676 516 626 490 626 490 626 490 611 541 550 436 788 712 652 486 584 485 712 552 883 734 739 561 658 561 739 561 611 554 611 541 626 490 676 516 658 527 575 569 563 569 563 569 563 584 485 765 572 765 572 765 572 765 572 788 712 676 516 676 516 676 516 608 547 608 547 992 767 992 767 708 552 788 712 584 485 569 563 708 551 765 572 909 708 550 436 652 486 626 490 658 527 575 569 563 708 552 765 572 626 490 788 712 676 516 992 767 608 547 569 563 992 767 765 572 747 563 765 572 587 574 584 485 739 561 550 436 676 495 747 563]1180 1185 0 1186[641 556 590 496 783 731 592 1083 878]1195 1198 248 1199 1202 243 1203 1206 260 1207 1209 340 1210[468 449 230 690]1214 1222 230 1223[462 394 462]1226 1227 396 1228[471 394 462]1231 1232 396 1233[343 199]1235 1236 390 1237 1240 230 1241[390 230]1243 1246 439 1247 1250 295 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 230 1262 1263 358 1264[593 504]1266 1267 495 1268[582 518 425 626 547 695 610 431 367 598 680 582 561 518 729 640 1067 1183 883 820 579 520 516 587 571 570 598 494]1296 1297 778 1298[454 476 475 1113 842]1303 1304 296 1305[432 564 503]1308 1309 211 1310 1312 499 1313[511 230]1315 1321 499 1322[504 499 348 725 656 572 575 707 375 290 203 358]1334 1335 378 1336[409 410]1338 1340 398 1341[161 178 571 398]1345 1346 405 1347[240 330 206 388 235]1352 1356 388 1357[362]1358 1359 388 1360 1361 161 1362[307 139 370 183 142 388 235]1369 1373 388 1374[362]1375 1376 388 1377 1378 161 1379[307 139 370 183 142 388 235]1386 1390 388 1391[362]1392 1393 388 1394 1395 138 1396[388 235]1398 1402 388 1403[362]1404 1405 388 1406[796 746 864 796 914 796]1412 1413 914 1414[838]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj242 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj243 0 obj<</Ascent 1079/CIDSet 244 0 R/CapHeight 667/Descent -325/Flags 4/FontBBox[-356 -325 1136 1079]/FontFamily(Proxima Nova)/FontFile3 245 0 R/FontName/BZVOLB+ProximaNova-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 76/Type/FontDescriptor/XHeight 483>>endobj244 0 obj<</Filter/FlateDecode/Length 16>>stream
+H‰šÀ0(@€ V  ™
+endstreamendobj245 0 obj<</Filter/FlateDecode/Length 336/Subtype/CIDFontType0C>>stream
+H‰bd`ab`dd”vŠ
+ó÷qÒ(Ê¯ÈÌMôË/KÔJM/ÍI,Iëÿþ!ÓÍ#÷C–ñ‡Ë9Ñß?~ß”a)øušU†e/Ò÷hþï)‚ßxT¿oâQa`eddãsIwLÉOJõLIÍ+É,©tÎ/¨,ÊLÏ(QˆÑHŽÑTðM,ÊVÎÌÍÏ+ÎÏÓQ0200ÕSpÌÉQ +*V(J-N-*KMÑÓw©,HU0QHIMÃæB `fÙÃ ¦Õ4=~ô®ü¹h%ãÍUß·¬fþáh(úóÞïÏï±¿¼Rô÷–Ÿ‹¾oaãû>ï{Uãw&Æãß™˜ïÍ]R´rå’%+W-ÉÍ-*Ê•ãyó‡<ÚŽïû…êfü(Ÿ~hú—ißYf³ý.›=s:»Ü3Ó™3ÿópvóp¯æºÁ½zYÿž“xx m„
+endstreamendobj246 0 obj[248 0 R]endobj247 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj248 0 obj<</BaseFont/JPZWYG+ProximaNova-Bold/CIDSystemInfo 249 0 R/DW 1000/FontDescriptor 250 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj249 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj250 0 obj<</Ascent 1079/CIDSet 251 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 252 0 R/FontName/JPZWYG+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj251 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj252 0 obj<</Filter/FlateDecode/Length 1407/Subtype/CIDFontType0C>>stream
+H‰dTkLgavvZÝ2³»>g¶²h„øhÄ(P¥ÈCAY`²Ëk|­±jM‰Fˆ">€jY-”7¥T­­il‰õ¥ë³¡Ñzïšv¶&ýÓïßýîÍ¹çÜssIBåA$9%*&y]ÒJÿ˜BK©ysz´Å–>g™%/Ó’Ù»\#ÊÓIY«’EÎ¥s©¼Uç^ÒÞª¬õ„=^°]3Ã›nÐø4IªÙ•ñ™a™–Sd¦)¿Ø\\n±–š³sŠ)~›RfV§æâÌ›-ùE–ü Ã¼  à@CX^žáß¢"C¡©ÈTh3eWÄÅ—YM†ù†LSÖÿø)"&¡%ôD$E¬%ÖiÄFÂDä¹„•( 
+	›ª›"Hw­–Ð*z‰„QDTwÈÉd ™Jî'_{Ä{´y<£Hju‚z òUå«öçÌ­¯­'¯7@K#%ÏÕã‹7ÃÜ¬×aËx-´¨Y<Æþé NŽŽl_¨‚TŒè0ôWƒ8ˆ0…Ð`ÅXŒÁPe=zfûøg?Oðl~òôIs zŠ¬¡Ú6n´“°> à¹~Üˆ“ÌÂì»!à4í*eØ{åà%/QºÉ¾àKÉzðÂV÷øPOƒ©HßAŸ@?sh”xwÝÙ~¹~Hø®/ÍÂÅ+ð¦J¨bØÛÕ6Á€+·sð|ø[ò=ˆ#à,ûa"ƒ'\Á4ªà&ŠT©0BÍ?‚h YÜ÷–äuð¡ ÓÍÑç‘asÝSèQ¸7(ÿ‡út)]e7˜þü'˜'ÉñèãŠe¢2ÒW¥škOˆ,,*‡@œêFâöŽGòV9\‡Ç4†¨y'®rÆÕòawoŒ4{Ú1ö3øÞ}Á5‚€ç·ÉÅz¸Æ€4³=–.-Z#v…ÐZºN~#¶æ&KÌÅÜØS	K‚2–øn$®»5p©öâ9‘/NbønxGe±mÚž!$eœiïhù²§å«í–j‰½á zæ4¡v¥ßdØZ¥ß)·Z-~Ît›NÇ
+èäóÜÀÁ¿½Üw¦ó‚Èo‹v#©rK6oÂ“.ßï¹tóëöâÜ‰=ïÕÈ«17(N†©°<ù—°W‡F ü`ÖÐPM{·wÞœ·¶lƒÀ?[˜Ü{õS	°Nóf¾"ÿgù"	@€î~ctê	w©»5]¹-°Õ6Ùnhçz  %eLcŠ/½ºÖ¦¦ÖVsSzFŽ9=ý¼¹Eâºzu²y—aßZ: <±n‘¼ÛÒ«
+76hNIÀz«]>ª‡ÇÌãÄïßÿ0Æ”•'ò·Ü À3|;üÂœ­¾X×#|{¾8BÂv†Íp<‡kÏH§²ä€¥ªt)½w-÷˜6t}4HÕ,¨’*LõÓêêw\é/Ì;+öüF_H‰ª[( ¿|ù"d^Ù‡·Jý;[æi›Jã??w.Gd1BñÈh“µ@qs¬PâÐõ5U?)ñNëSz÷î²Ý¥‚ekm½ùÏšSç¦,FêdxkpWê¨È^ý×h™³ÿ§°TQèŠ¢ï0–’Lk²SóƒÈãSfNÏš¿n_nv*+TÍ°{1èÛø|;·G®á­¸FÇ;?«jÜwLÞ?øEóC°ËW¦àt5r8ŠŒÒè­†D×Ž²ºÀQ²ëÁ±åÀÁ’rHvBÙ	!Tçº4gV[›ÓÙÖ–åLKËÊJY÷%ž Kš™}Þt;·ã¨l?Òäe¨ªÔh«ª<ÂˆÕ!Á••kÞ-×LtN ýDgÿÁãè+5ïÁ!­|L÷  ™ú¸E
+endstreamendobj253 0 obj<</Filter/FlateDecode/Length 4072>>stream
+H‰lWI®ÉÜ¿SÔª”ó°µxe†>À‡Ý½xj Û÷Á «¾Z‚ ýÇ²˜d0"òË?¾_þþ5ùë×ã•®<Ç‘®Þç‘?~y}ùÛ¿ÒñËÿ^½¬+×rìãìyÛÏ¾ûUÖñÇ^ÿ}ýþJÇÈ•ñêûZxÌCÜþ÷ñÛ+YþŽŸ	ÿ¦qµŒGk±®ããÛ‹·¾½æ•VÇ¯÷_Íå8‘WªÇ¾Rzf0:îä« —WNW›õ8Ë•zÃÚ×^ó8ëÕv¾£~Í®G-\WJûˆ÷U[Ãª³w¬š®4*žåV·Åsåc]5ãÅŒîvÌ«îzGÈ=~¿_¿2*íJeb?þžÇof0æ¾/ R©e„Õv–û•7/W[ƒ	Ï« ©’¯6Ž¼®½Q-ã*kÇ¢àrÅ’/<µ¹Ÿ<®QÛ5KâývõÅh—†KæŒf¶Á2pŸîçµñRDýêÍö˜ÅÝxÕö€•W)GFR–E=ê•W=ÎÄÂ€JL¶ õ·ž­k ëš¸ˆ|WµväÑ¤;ñÔ3o{´`7þ¯ÅúÉd­ÚåêÁÇëD5÷hqá}_8[bßìLüüØýçgL6Tmg”m¶+·YLže@¿‰Ê³£Ú‰¿ÏúE³ßéLæa‘ý÷Ž€½àéíÑ¯ÆÖøÂGþóý*×Ä6Û¨/â—ýx)Ð—ß)'-ìrš {ß‡ÿùv_8ÕÙ÷sa^k ·±PêzÄ‰Tz¯ŸÄ~”ûÂ›šó¹€Fîq¯‘>‡·ûGßwìà/5ûUù®¾ä¬\ü‹¬dýÂ½Y-ö§½Xç3qE”. "uPæ¿ž»S[€£ÍŒ·yÔ´cÎÏ¼N¢AB™µ6†:‘J®WR"ŽO^Å8©äíÇ[íZx£.ô€\8©uc*üYW«FT˜s ¨Z8ÉiyÌ)ß˜¥	n\ˆÀ£\¾¦l"k†™dB÷$A5sFZZ–¥bÌë1¡´ýû1>ÉT¾QvÿÙŽ~³Ù Š]ï):«…Dv­œÏX(Ôk¶îénL9ª9'·ößÔ¦l¤a(Œ><(0©½LîË‹à·€O™Ò¾ãò {®ÍB´mü=Q#ð$4l®.Á” ôpªg÷ç1 ÅR5ZW'Oÿ€G|Ãà1èsCÚ@G`ùöcÌ%÷2‰yf%j¤™þžÀjêlrÙû‚d÷O…2±^VK€>ƒ?1Mí ä‘UÑVM–nrÏÌYÐ·uÜÕ ê±Œ ~LæG‚RPèÙD/MúózÀ2C¬!Aý©Ý™©a"jUwÆÅÄ™†TlN@88†çŒh¬åM¯˜7ŽL¶»mƒX'Aa4Oˆ;jFé˜=ÖÍh!¤fÓ±·CdR…Pu[®¢¼R—VfŒ‰ÁÈžÖðyìF4ˆ^u›
+oRNP$².r a .c“·‘O¥ð¼Ô_ˆ@˜ÈÜÁLÕ%'…‰­j›²VÌ¶mÙ€K6ÀÄ$c~áÖ®ÑÅ¡gy!:‡pšïQ«Ì€4ïNÅàS¬‡:ÂçlÞ–MåNf`XNòHRšÍ¨6ã»ZåêœÆ ¾ÅÈy:í2è¶†‘Æ,=‘¦PÏy–›À EtFZkÎôüPwã÷#HßU5|âqß¦œ[o“Q_µ:RûcOhÞ’E¬­„•L’¼MáI&o!gàµÙNý‰„1©d/md'áÄ‘²~Áiˆ=·`àíS~rêT±X0£4ÊÕ¼ÝÎõŽn’R2H´´›¡5ÿX/ØhR]h³%ITz3æê*ÞZ!nÛdÛ…ó*UÝ[|;äHõó»ÀNY2bÙ	åÜ&¬Ñ‚ìJ”·rØ,S(‹ÓRpC ýé­ÈIÉReCXîn*´¬<žû^zwÄH›f¤Um›{RhÙŠo[•ê°³ÉÇËÃÆ“‹kµäH>êf½O1:©aJŒÖOE¢%æ‡q¯dÐñY%P)Ò€˜(ZVL!ÅÀPÅ¨Þçj'£Ó§õÊ:/‘ÃüÔ/há·UXVéû¸b“Ý³ãæ‡¦×UÌMó0EkŠ&BN1þéL Ù²A±";VÅ¥>
+ÙÁÕÒ2ã\Ã’†§cH¬éû²²>A`—HÈÆ9ÐøghLátB]7·¯Á+nyžñÞ¤™”mµs/ÂƒÒéé»U±>£n&5|Dœ_8M†ÌÍþ	S‘¤ÛÅ>in5†Â	Ä…ûá×† Óm ¥!XÆƒš–P‘®Y>QoÚ!ß&4¦®Þa=O¡¹½ºvSk®ÒÖÃ|4…š›_kSè#«·Ò!Ùf{H2sß<t.zGZ¾M¾m¬xªF5Æêêw˜bNÍQÐWút^ðHž~l»mdoÞa–Ýæ„e”›h“ÿX‘†‚8yH	÷²e$…ÌŽ:¨¤|©¾yYKåNl1ÿ¾A&þ:×§=—ìäRê¶d¨xä61šgŸ[}y¤ú¨5¦†ït–ÅFAðQ	•á{:ð÷ÐˆîçÅ!IcâSá 
+‡­ßŒ’LêšÁ#¡¾ÙÔ2ÄRG—
+p†Q	›(#Z Y¶÷#:Sô'.8“ø»çsô²¿*‡ÌJc±ÂËø¹ÈO‰hiÝ*–e¦%OQoßëE‹ ì{øH¯šm.ÒÊÏÌAßò.ôT‡îÆµ—T}%I¹Œµúc d”ÜÍ8áÆ‰€S^yNžÖÖÀ''ÇÎØ+¥´žÂi§¯8‰Œu;ZŽ‰àãå,év_g©'’Vk†?^ÔˆxóíQZ‡f=ôŽˆð¾ã…¶fÖC»ÑõE„’¾ò]Â€v{Ÿ
+¬žfm¼Îw®üâ;÷…÷¹íô³š£Å1æÒ¨ÈZjÖÉï¢åKÌCQ¯ŠPóªá.N#»!kîqú'[¬óÛCë¹spr’¡&5>Š1¡ÿ6,“±¢A– BzDÂµpÏØÏ
+þæíÓœƒy$‹£"ó0f,‡¤*“çqè{0ê>%Ü£ÊÀìMS6U“I7 Jb™½¼Î ^|n«waçágÍ»S3ávx"½ \¥¨qÁýxIÂÜ(S”Jµôz˜Kç9CèÊnâëhérÍô§ ò²n•ÏÂˆNÇÖc×¼9ì´##ç=ór$à_Z„ŠŸ.ƒù°#ªJTnßH”Qb!eˆ9u+.ƒß(aRŸÝéá{*|)¶¨3‡.ßyØ˜}Æn˜©àBUÄ£[9ã®0›5(Œ#Yµ:øÏïFÖêbÎcÊIÏ`:Oiò<	Q%™’vˆçZÔbD¹MbF!Ú¨ÿÿë_96¬cÅ`äsS2˜	šmq‰PòÄ3ërò‰ÄuC˜ $Ù1é| K¸Ê-ånÜ”†k‘GžMbU UdM5mlà>-ì(
+eAH‰Pê<ø¥ì{rë%ÓŽ€&UBòËÓvúQgWJd—ÍJeÜ’hÊG;[°DãpAe×9ànŸTP¬UŒ­¤úxÈ&M`ã”›Áãvò«Z×i$Åç\æ±CKç;%ôû"hMsê‡7·T÷±3d–]‡ßU[ÇX|öTGw§~TDÛ’ÑœïÀ4˜.>ç!º«"Ý÷E'§[Ü8h`­•˜‡’ÆÜ• Žÿ'½\zë(‚(¼Ÿ_q—€4¤ß=#!¤ØV‘Xë(²0º	È$?Ÿ:uª{zìØ`±°ÆÕêÛêªS_©J³ôèlUåzjí‰Å„5œ¢PŽ–“ˆ‰uBIÂÃ‰Ru ”ª
+^{
+ìJ•,T|½mœf*e"NÝÔæÙëšbcybmªZ•Y't¼ò)‚fŠ×†Œ´ÛÝÅ€•Ù­`sžl<ÍàWaêæõÔHš6¸‹;­rêÙîR:¶È—:šW‹%îÖYÍ¶k°3ìŒ‡\B`•ªªi\o-z33K–¬„\ÚçnÂv››u›«ˆáDy"u,ˆhvÕÔZ“¥”Åò Õ4à²QœÒòb#åEuªfº‰øŒ”	½è8fÍî¢QY/Ø~&ÏjÑAínÍ”YóUnµG¬ªÏÚ8÷Ko0àîv/äf›Ü @Á@”t±<++_^·ÄÐ0´'¶”Ùpê€=óM‘¢bµIÎY°ð<˜ïQXÆXCM\E°5€L…gë@ÅšÙŠžÆvzÒ¸*M$©\&ˆF$­^Ó‚Ï²
+¥œûÀ,Ss¼ø…²¨úQY¤ÛöhÆª€á0t\Äjthtîb=•EJÕ,¡{×“…#CR?iìàª¦ùô¤¾¶àæ ÿož§Å_édÉ”Zm 5wì7ŒtÙŠŽ/ó(C’Ü9Å¥Š¸§ˆeƒS‘Ÿ­€X+h:Ãh¸žZO	«"›2Äu÷#§Æu€£­P©dGÉ´¬qÏÞïñÀžë·Áq¯\óÀ9òHyÏEU/7w»5¾¢ÄPjÍ3ÀRjòÅÏ“=¶³¸3ú"´<pmv²òÊÕåòKQîHrë$$Wž!9ÿÉ¥gH.þ;ÉjÀ‡Ö€z,ù?”€ÿÃŠËÈŠyOkîº˜âÊ”Ë™00 ’²3 2ÀõTPí'ŽX4Ö;j³²3 °£ÁPÏÑP¢‘×e`@8£3]u`@­3;†<"àrÀÓ€ˆ° Ö€Œ« ×e @_ uD@Åé×z„ÀåÝ)0æ2R Y´S jÝH¥û)
+\K)PÄY¼Q`Pýë¨ 0,#FïGŒi7Á€¼Æ€9ªDæè¨u§# –¤Ý”È¶vG@-{;ª£5Æ*˜¿H€Øy·PØŽÊÀÊ´@4E‡ä!R"Â—W¸ÉŸîouÖÅ¦BêN÷¿N¯6ÿr»½—¦Qå“ÉN<ep’ÈèöaúêâþÝÇ›¯·ß‘ÎUIŒÒñ\$q‘Ô‘,Z@.’¢Xä§Ïw7·ç»·a¥«M~ûÇçëß~ùóívû÷§«›»O§7?OxépB‡Õ±&H¶Jù‘HÚn¦ï„&såGù“ouüæŽå+ù&—..íù–×2!~‹à1OÛ/YEWÀ<]á™À!¾]ÀÛjQI)R$-íü²UÉÜµÛuÁK«Øvª"ãÕÛ\ùÖÂ9>ðdýëÚý¶o°~zÍuñûâì7‰óô[ì&Wo.OÓ? Ô™8ù
+endstreamendobj254 0 obj[256 0 R]endobj255 0 obj<</Filter/FlateDecode/Length 320>>stream
+H‰\’ËjÃ0E÷þŠY&‹àGühÀ7/ú n?À‘Æ© –…¬,ü÷•gL
+Hâ0s¯¤…uóÜhå |·£hÑA¯´´8w+®xS:ˆJ¸•hCg‚Ð‹Ûyr84ºƒ²„ðÃ'ggØåxÅm¾Y‰Vél¾êva{7æÔ"¨*Ø{£—Î¼vBH²]#}\¹yç5Ÿ³AHˆc¾Œ%N¦h;}Ã Œü¨ ¼øQ¨å¿x|`Ùµß¥ô½O¢$ªŠ#¢ýJ	SÌ”2%L9SJ”ˆüFtd:eœé7¢QÎžÙ…‰]r>=Ï˜2&öÌŸ˜j¦ÕåLT°®Ø3ÅLìYð
+ö,ø.y¦§šß~¦R­5YŠæ{Žˆ»µ¾ô¨Ký•ÆÇ1£¯Zfð+À J& Á
+endstreamendobj256 0 obj<</BaseFont/KGZFVT+ProximaNova-Bold/CIDSystemInfo 257 0 R/DW 1000/FontDescriptor 258 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj257 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj258 0 obj<</Ascent 1079/CIDSet 259 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 260 0 R/FontName/KGZFVT+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj259 0 obj<</Filter/FlateDecode/Length 26>>stream
+H‰šÀ°Š˜[&<b$€ À 
+'¬
+endstreamendobj260 0 obj<</Filter/FlateDecode/Length 1407/Subtype/CIDFontType0C>>stream
+H‰dTmLgÞeoo[½.²{w¢‹»WŠˆ94BühÔ(¢RDDA¸‚Üñu~±jM‰Fˆ"~ Õ" rZ( `)Uk@k[cE±TbU°¡Ñ:‹s¦ÝÓ¤úþ›w&Ï<Ï<“!	•A’¤÷Še‰KããWç[ŠÍ[R£-¶Ô‹,9éî\ˆ,È>eQžBÊZ•,jt.Kå£:÷ºöQui|!ÞöxÁÍTº^ãGÐ$©f—Å¥G¤[ÒLËÓM¹…æÂ’ÅkI¾93«Ð°9iºaUj~¶!Ö¼Å’[`É2Ì
+		6DääÞòM¦|›)=Ø¸46®Äj2Ì6¤›2þÇOy1à-¡'–QD<±H!6&"‹È&¬D‘OØTAºkµ„VÑKL%ˆ¢œè''’Ád2¹Ÿ|íçÑê1B‘Ô"êõHå§ÊUíÏšY7VSGÞ¬‡æJ©Ào¸]§Ãæ±hV³xŒýËœ¼8²ü ¦R0¨Ãðß0b!f" ÂC!c06Ã1\”õè™˜9žàÙôløYSzŠ¬¡Ê6f´“°>¢à¹~ÌˆÌÀÌûaà4í*fØeà%/PºÉ~àGÉízðÂz–÷ôOPO†IH÷£op€9<J¼?ƒ¾ÔvµîŽð}wîš¹ó—âL–PÅ°÷ªl ‚ÔWfç`|ù»òV=ˆƒà*`ƒ'\¡4ªà6ŠTª0RÍ?H¨§YÜ÷ŽäMð¥ ÝÍÑ÷‘a³ÝSèR¸×+ÿ‡ºuI½%·˜òüg˜%ÉqèëŠa¢ÒRW&›kNç‰,Ì+ƒ`œäFâöŽ-ç­òb=3Ò¦æ¸ÒuWÉ‡Ý”¿1ÒìiÇ`Ä/à÷pè× ZX<¿].ÔÃ$ÿVôX¸°`Ýj±#Œ¾ÐÜqò[¡¯%;QŠd.fÇœZ!,ICZâ;‘x¼înï•š‹çD¾p=ÃwÂ{*‹móŽ4a}Ú™¶öæ¯ºš¿Þa©’Ø[ ýG¡h·+ý&ÂvÐ*ýN¹Õjñ¦Ó´ötŒ€ž!8Ëú‡Ø«Ýg.]ùíÑnäUvÑÆÂMÂâõWv]¹ýM[avµÄžwŒ‚jðÕ¨'Â$(OþeìÕ¡¨ ˜vçNu[§û€Þ’_²QàGæ&^¾þ™X«†YÓ@?‘‰ÓüFƒ H÷°!:ù€„»Ô‡¯ÝØ*›l·?¶s]„’2¦QÅ—Ëº–ÆÆ–scjZ–95õ¼¹YâŸô¹.ëd;ò.;Ã¾³´x
+bÜ"y·¥×(nÔhNIÀ«M>ª‡§ÌÓ„>üxµ)#Gäïöº€gø6ø•9[u±¶Køî|a¤„m›æx7FH§²äs€¥ªzuI—ï[
+0ùÎÍ!Ð U=§RZ[n*¯›\[w¼ýZO~ÎY±ëwúBRTí\ù%Kæ!óÊ>°Mê)mq˜'oÉ+Žûdñ¹sY"‹‘ŠGF›¬Š{¤˜c…"‡®»±âøI‰wZ‡éÝ»Kv–m5uä>j:x+ÎyÏGª2¼5´#yHd¯¿5Zæìÿ),Vº‡¢èÁ~ÆR”nMÖfUÿ(A;ò8ÌÌèZó÷½«MNe…Š£v/& f›mçöÈÕ¼µ×èxçç•ûŽ	ûû¾lzvùš7NQ#‡CÈÁ>jHpí,I£óE»>[,•”CR
+aä%£.ý¤Kqf´¶:­­Î””ŒŒ‘u_âq²¤ñïö¡Û¸Geû‘ž#/ËAU©F[eÅF¬
+­¨øGó~™f¼sèÇ;{×h@_¡ù iåcº A¥¸6
+endstreamendobj261 0 obj[263 0 R]endobj262 0 obj<</Filter/FlateDecode/Length 288>>stream
+H‰\‘ËjÃ0E÷úŠY&‹ ÛIì.Œ!Oð¢êæiœ
+jYÈÊÂ_y&¤P‡¹w¤¹’‡úX[@~øA5 3V{‡»WW¼+Ò´QáAtª¾uBFs3ûÚvƒ(KŸ±8?Áb§‡+.…|÷½±7X\Ídswî{´¨*ÐØÅF¯­{k{I¶U­cÝ„i=Š¯É!dÄ)?FG×*ô­½¡(“¸*(ÏqU­þWƒíÚ©ïÖ“|åI’%ÕLÛ„hû =Qž2˜ÖD9+ó-wÉ¦ÓÓŽéÈt`:3‰ŠŒ¨àžÝ°Ù³2;Ñ Ï#Åäá™—º{£¢ï¡ŒætŒÅçºÁAtÍ[ü
+0 ,ó
+endstreamendobj263 0 obj<</BaseFont/PVNYVU+ProximaNova-Bold/CIDSystemInfo 264 0 R/DW 1000/FontDescriptor 265 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj264 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj265 0 obj<</Ascent 1079/CIDSet 266 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 267 0 R/FontName/PVNYVU+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj266 0 obj<</Filter/FlateDecode/Length 23>>stream
+H‰šÀ B34	à 0 U|l
+endstreamendobj267 0 obj<</Filter/FlateDecode/Length 1168/Subtype/CIDFontType0C>>stream
+H‰d”LgÇï¸^µœŽãªóà®#€œ 
+Ñ…ðcÍ¡¨Â
+´ÕÚÂ1hZˆs°™l™8³eFltZÉhª‚-Ðª«?ƒðÇbÆ±³eÄçØ‹Ù®$ËþØ›¼ÿ<ß÷û>ŸçyÞ¼8¦Ãp_U¬-,×–%7ŠÍ¦ºêBÑVýú›¢EÒR%NŠnWñR.E)$^Å.°ŠhEï_Èh…_Úå`DU|´¢]‡‘8®¤ß.ÕçêÅÃ;zC½ÕdmÉZM{÷Y5•‰µ•IšíÕfM‰©N¬oë×jÒRSÓ×ir-Íâ¡&M£¡ÉÐh3è×¥¼URÚÒ`ÐlÔèÆÿñÉ‹ÀŠ±÷°*lV‹é±ý˜±…ÀðEÈbñXfÆÆñ¼ÿ3,%ì«°	"’¨#'¬wÍwºðÑnèë!¤ôõì|Í¾RðÐÅ¢¾ùNèSÒôU§Û€ÆG!>‡xôj9–EAÜÓK2Ÿ¡x¼LQÊý*gKª÷–ð(Y¶$+oõKº¦õqî÷7õd6²¢ æÉª†
+„
+ËÎnÚYÌe—û†Nßàô›+„-ÔóŽ3[¹¬ÔD
+Œa¿ì¾Ýy¥—g¬åãƒp…h«=XÃ•×œóô÷÷]=(::£H¸$Þ+‰ø„EI/b!éù½kÞ~Ó8i¶î³ë¸¬²ÛSSßÞ÷\jÞß)ÇI¯¹èZ"‡’4±(Q -­3 xübFæ]‰VÂ«ÐË™¹ÅÛR€H„5ccg½>¾ä'²Î¢m©â˜éÍ×ï u)!-	0Ç3shM"‘F€£°–ê)Ü}T@+‡¾¼xw‚£ ]³¿Ë¨§g€åÅLÞD+Xí½‘æ Ë ÖÛfZÒ¢(Š™ÜNùô;¿y—Ctê”†ÒÍ€ˆ»7º†.ÔÚ¼†ÂÂ]§®éypƒŽµØv7Usyåþ`ÐïØ?`5ËùÔi“"åŒ9v|¨†jxJý¶ëÎk™E£…‡vÄ¼L‘ÅGÔ…³Wº|\à’m‹€)œ!÷"kÈœ#ÏQÞŒo¾[PÏµƒi¹[u:‘´Tõæs¹[w×Ûfr1v`BãzD?ívy¸gÌUº#û'¨s_»]Þ#ýÑ£[í°Š€«­,l|*?2b’!mD’Q8ŠAüS ™º‘Æ<#Þ‚œìª‚LFVu	D´Ù»í!XæìP3÷á!Õí¼ÕÙÏ9:vL€TQ‘iI`.Œ†()ZÓúF¦q7,‡M@Îa¶òú¤8ÅÁê±Ñ' BÄÙM'…²ã†ã®Õ]®Sw–¼ÿgòreA×f1ùùo ê…=x@´õ·šV×½ß\Z”×Û»§Û „bð;Vç6z<n·ÇctëtF£Ž§C_ÍRIP%ÜŒV8"?<!Ù;sÇAqR‰l'ïÌHw8þV-iW-s/õ2wà‹S*¨ª8%M²ÿ0 EU,¶
+endstreamendobj268 0 obj<</BaseFont/Helvetica/Encoding 270 0 R/Name/Helv/Subtype/Type1/Type/Font>>endobj269 0 obj<</BaseFont/ZapfDingbats/Name/ZaDb/Subtype/Type1/Type/Font>>endobj270 0 obj<</Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 160/Euro 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]/Type/Encoding>>endobjxref
+0 3
+0000000000 65535 f
+0000946189 00000 n
+0000946337 00000 n
+5 9
+0000991396 00000 n
+0000991857 00000 n
+0000992317 00000 n
+0000992785 00000 n
+0000993233 00000 n
+0000993680 00000 n
+0000994141 00000 n
+0000994629 00000 n
+0000995117 00000 n
+22 1
+0000995639 00000 n
+95 176
+0000996101 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000996320 00000 n
+0000996461 00000 n
+0000996932 00000 n
+0000000000 00000 f
+0000997488 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000997629 00000 n
+0000997770 00000 n
+0000998241 00000 n
+0000998797 00000 n
+0000999267 00000 n
+0000999738 00000 n
+0000000000 00000 f
+0001000207 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0001000348 00000 n
+0000000000 00000 f
+0001000489 00000 n
+0001000630 00000 n
+0000000000 00000 f
+0001000897 00000 n
+0001001038 00000 n
+0001001179 00000 n
+0001001320 00000 n
+0001001464 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0001001605 00000 n
+0001001746 00000 n
+0001001875 00000 n
+0001007189 00000 n
+0001007263 00000 n
+0001007295 00000 n
+0001007381 00000 n
+0001007726 00000 n
+0001009522 00000 n
+0001009606 00000 n
+0001010065 00000 n
+0001014083 00000 n
+0001014167 00000 n
+0001014746 00000 n
+0001019793 00000 n
+0001019820 00000 n
+0001020211 00000 n
+0001025336 00000 n
+0001025406 00000 n
+0001025686 00000 n
+0001025782 00000 n
+0001027282 00000 n
+0001027396 00000 n
+0001031750 00000 n
+0001032005 00000 n
+0001032260 00000 n
+0001032508 00000 n
+0001032572 00000 n
+0001032636 00000 n
+0001032700 00000 n
+0001033144 00000 n
+0001037021 00000 n
+0001037048 00000 n
+0001037439 00000 n
+0001042564 00000 n
+0001042634 00000 n
+0001042914 00000 n
+0001043010 00000 n
+0001044512 00000 n
+0001044636 00000 n
+0001049029 00000 n
+0001049471 00000 n
+0001053348 00000 n
+0001053784 00000 n
+0001057752 00000 n
+0001057779 00000 n
+0001058170 00000 n
+0001063295 00000 n
+0001063365 00000 n
+0001063645 00000 n
+0001063741 00000 n
+0001065242 00000 n
+0001069790 00000 n
+0001069817 00000 n
+0001070208 00000 n
+0001075333 00000 n
+0001075403 00000 n
+0001075683 00000 n
+0001075779 00000 n
+0001077280 00000 n
+0001086398 00000 n
+0001086472 00000 n
+0001086504 00000 n
+0001086590 00000 n
+0001086674 00000 n
+0001087253 00000 n
+0001092300 00000 n
+0001092384 00000 n
+0001092843 00000 n
+0001096861 00000 n
+0001096888 00000 n
+0001097279 00000 n
+0001102404 00000 n
+0001102474 00000 n
+0001102754 00000 n
+0001102850 00000 n
+0001104352 00000 n
+0001104466 00000 n
+0001104578 00000 n
+0001122546 00000 n
+0001122573 00000 n
+0001122971 00000 n
+0001128096 00000 n
+0001128166 00000 n
+0001128446 00000 n
+0001128543 00000 n
+0001130192 00000 n
+0001135046 00000 n
+0001135073 00000 n
+0001135471 00000 n
+0001140596 00000 n
+0001140666 00000 n
+0001140946 00000 n
+0001141043 00000 n
+0001142690 00000 n
+0001150835 00000 n
+0001150862 00000 n
+0001151253 00000 n
+0001156378 00000 n
+0001156448 00000 n
+0001156728 00000 n
+0001156824 00000 n
+0001158326 00000 n
+0001162718 00000 n
+0001162745 00000 n
+0001163052 00000 n
+0001168134 00000 n
+0001168204 00000 n
+0001168486 00000 n
+0001168572 00000 n
+0001169001 00000 n
+0001169028 00000 n
+0001169419 00000 n
+0001174544 00000 n
+0001174614 00000 n
+0001174894 00000 n
+0001174990 00000 n
+0001176491 00000 n
+0001180635 00000 n
+0001180662 00000 n
+0001181053 00000 n
+0001186178 00000 n
+0001186248 00000 n
+0001186528 00000 n
+0001186624 00000 n
+0001188125 00000 n
+0001188152 00000 n
+0001188511 00000 n
+0001193636 00000 n
+0001193706 00000 n
+0001193986 00000 n
+0001194079 00000 n
+0001195341 00000 n
+0001195433 00000 n
+0001195511 00000 n
+trailer
+<</Size 271/Root 1 0 R/Info 95 0 R/ID[<15C714B85E4E4D4F8AB0F10B2A2B6432><9F943EF30110224790C8FBE4FF680222>]/Prev 944117>>
+startxref
+1196704
+%%EOF
+2 0 obj<</Length 44981/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 9.1-c001 79.675d0f7, 2023/06/11-19:21:16        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:illustrator="http://ns.adobe.com/illustrator/1.0/"
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Presearch - Brand Guidelines - 1.0.0</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <xmp:MetadataDate>2024-06-26T14:53:48-07:00</xmp:MetadataDate>
+         <xmp:ModifyDate>2024-06-26T14:53:48-07:00</xmp:ModifyDate>
+         <xmp:CreateDate>2019-01-29T13:30:10-05:00</xmp:CreateDate>
+         <xmp:CreatorTool>Adobe Illustrator CC 23.0 (Macintosh)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>20</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAFAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8ADPbXKQpO8TrDJtHKVIVv&#xA;k3Q9M9WE4k1e7wBiavoj/K3/ACk+kf8AMbbf8nVyjW/3E/6kvubtN/ex/rD7305a31leK7WlxFcL&#xA;G5jkaJ1cK605KeJNGFRUZ5g9yxjW7yG31thNDdujKrGSGScIONaUjjotSeu+Z2PKBjra/wCqD9ri&#xA;Thc76e8/cn1mUkuIyHO0fML6rA7kj4ofp65hz5uTHkk9n5kiu/NdxYW8kUtxChjnt1u3PCKOZkMv&#xA;oelQPyqp+LtSuZmTHGGMCRqRHEPT3jvvk48JylMkcuX1d3lXNrzjqtjZXdkl2ZQjBjWKaSI06Goj&#xA;py+k5DT5BGJ7/wCqD9/JlmgZEfrITLSNV0w6Kt/64isQaCe4fiBRvT+J5D3bbc5XKMskqiLJ7h+g&#xA;MwRCO5oebzz87kbUD5dFgDdmcXZhEA9TmKQmq8K8tt9s6X2bPh+Lx+muG72/nOk7a9fBw73xcvgk&#xA;f5dM2mW2vC+jlgdBaiSPlJbyglnI+JRzWv4jMjtzLH93IEEerukOjT2Xjl6xW+3k9L8u63De2t0N&#xA;JUyXlvGrtFcyyMlXJAHqvyanwHOXnKMpeo+nyAH2O9jGUY7DfzP6Uu/Mm5u7ryLqPrLbJDzt1EsE&#xA;7Tjl66V5D0kpQb7V+WZ/YwgNVHhJP1dAP4T/AEi4naRkcEuIAcut9fc898r2ukW3nnRP0XM06mNz&#xA;OrrIrCYQvypzRPhb9n8c6LWzyS0uTxBW+3LlY8zu6fSxgM8OE3+ui9Q0CZjccGtrqJgAA808s6kV&#xA;qa+oaA9Ogzk8+QS5V/pRH7noMMCOf+6JS3T/ADX5t1jzXdaVpl/pCWtq8hlDWt3NMkUciIAxM1uh&#xA;Y/Eu3dgdwpDa5zGSWWt3M2qCzeS2ZeTqRH6gf4AT0YU7eOKsf1PzFpVr5iuo7r10MUgqy3E3CqqC&#xA;KQqQlD3zPjlAxgbX/VH383EOMmd/74/cy68NwNLP1f1/WovH6sITL9oV4/WP3fTrXt75hS5uVHkh&#xA;vLthqdvarNf6lf3klxFGxttRWwWSBiWdlP1GGJC45hG+Jl+Ece7NFKV+dNWtLG6tPX9QlkcqI55Y&#xA;AdwDyEf2qe/TMzTZBEG/9yD97jZ4EkV95H3JF528xLbeS7PU7G7ltY3uUhWX1pIyRwkBDOGDNvH3&#xA;OX6XDDLlIndUTtt1atRkljhced9UD5i84/mBCnLSpIH+r3hiuFEUbsYAe4eSMhtt+IPyyvW6eGMQ&#xA;4b3G7PS5pTMuLoWWXGrzv5Liv9TSSGZ2AmVWe3cESkChQclrxH0Zj6eQjKz91/YW7NEmND76VvKO&#xA;pW18jmBJV4Greq8koPIbcXk3PTpk9RIS5fdX3MMMSOf32wbzSnPzAWs7CID6yfrD2mpW1GkVuMbT&#xA;RyR8kkBrxj7mvdcxXIZ/5V9BfLEIt4oY1SMr6UFyLxQyqBx9cKvIilOmGPMIlyQfl/kXJaC5i4/C&#xA;rTzyzctwekh2P0Zn58glyr/Sgfc4mKBHP7yURL598uxyyRNMS0TtG9ChHJGKsPtdiM17mKll510O&#xA;9u4rW3kLTTNxQVTr/wAFiqQax5j0+z165jlEpeOVS1LmZUFAOkS/B8x0ObGGSPABfT+aPvcOUJcR&#xA;Nf7I/cnmpa1f6TOLm7lsINC9IKJrqf6s/wBYJJp6jkpx4KdqV+7MCQ3coGgo6f560vUbkWun3ul3&#xA;ly26wW+pQyyHtsqKTkaSSHhkfmvzPbaXbWUU7wWUW0JVAvIci1C1PiFT0OelnQ4JZDIi5F4karKI&#xA;iINRRGh+YdZvvMWlRXVy0kbXttyWigGkykdAO+V6nSY4YZmIo8EvuZ4M85ZIgn+Ife99ttI8rXE0&#xA;l1bWVjLMs/OWeOKFmFwh5cmZRX1AWrXrvnAfm8tcPHKqrmeXd7nrvy+O74Y3z5DmuuJofrbRc19X&#xA;r6dRyp4064YRPDfREpC6ck0ZuFt2kdTLGwHExrx3J5A1EldvllE+bbHkwmHytpi6qtzBqt78Mqr6&#xA;vr2zLWObm7s/LmasKHvTbAUhmWrQaYXhS79N2VaR+sQWPbq25y7FAkbBrySAO5au9H03UNDn027H&#xA;p2MnESBCEoqEMN+gFVyePPLDkE48wxniGSBjLkWAfmpdTaDL5Un0p+cloLr6vI/7wtVYhUn9qobO&#xA;g7DgNQMwnylw3/snUdqSOE4zHnHi/Qg/yy1D9Kahr13qgiDTC1EqkBEBQOqih2H2RlnbeAQx44Q3&#xA;A4vPua+y8plKcpeSfefTHp+gRS6deHSBNcxLJe25daIVc7+j8TD5Zr+ycQllIlHj9J2NeXe5naEy&#xA;MYIlw78/7GKeSL651PzPbWWp6sda0+VJjNp7m4kjbhGzqzRTIqMQwFOprm47RxRxYDLHDw5CvV6Q&#xA;dz3xNut0WSU8ojOXHHfbc9O4vQ/K2k6QIbq5bQ4bC6t5ZPq8zWxjf0iKI6vIisCVrUDpnO6vLkBE&#xA;RklOJAv1Xv1HN3OnhA2TARI5emtvkm8E0MpDROsig0JUhhX6MxpRI5t8ZA8kJoctrHr2pWyreG5a&#xA;ru86P6HFHJ/dyFVUk+t9w9sjk0xjjE7FHz3+TKGcSmY0bHlt81ul/WpNdk5LcrHG0jEyt+7I3UUH&#xA;AV67b5jNyhfeXfL13qlzLLGst1I3KVeZJFNq8a7ZkiB4QaaDMXVpnrqxN5flWWOGVCEqlxA93Gfj&#xA;HWCOjP8AR069sx8nMuThNEH9NfagvKvlw6bPJdpDpUNtcRAwx6fprWMwLkO/qSGeXmGbenpqa9ch&#xA;EU2ZcvFt6vib/Qi9cs9IuZ4Vvo4ZJKUiEvGu56LXMnFAkE04mSQB5vMf+cgZrbSPy3tPQjMcK6nC&#xA;qxxAD7UM5Ox998tx5eCV+TCcOONM3/w7c3Wn6nDbTBJ5pnMcjqrgEg02cHxyWqzE8NfzWGnxVfvR&#xA;VroQs/Kyadq1wJKSFpJA3pqKuWULTjT+uYuKJJoORkkAN0XoOl2Vi7G0LFJgDVnLigBpSpPjk8go&#xA;MYG3nHnQ6UNb5TX8Lv8AXCClxZyQsjDlVFdLciQGtPUJO3eprlDa9A8l/V18pW4huPrESo1JRbGz&#xA;XauywskbKB7jDHmg8kZBNDKQ0TrIoNCVIYV+jMqUSObRGQPJL08h6cmpTXourkCYszQrIUWrszNu&#xA;tG3JH3ZiOQmEHljT4J45kluecbBlDXEhFQa7gncYqxjVvJtjqWu3Vw97RpHLPAnEutAB7/qzJGM0&#xA;D0aeMXSZ+ZfLl9r6wWV1DZ3OhikrQyiZLgTKGUMkiOAKcv5a5COWUJXE0VnhjkiBIWEHof5TeVdG&#xA;1SDUrK0VbmA1jdpbmTjvUlRJK6g/RhyanJMVKRI80Q02OJsCik5/5UbwFfR4fs/710+jN/8A66ef&#xA;+xdV/gPl/slbTv8AlS36QtfqPo/XfVj+q8frNfV5DhSu32qZDN/KXAeK+Gjf08urPH+S4hw1xXt9&#xA;T0WL0fj9Lj9o8+NPtd6075zjuVGT6j6x58fV/HLBxVtyYHhtVj9D4eHGv7PjTfx3yBu92QWL9Rp8&#xA;HpUqa049a7/jgS1c/UuS/WOPL9nl/DLIcXRhLh6qkfocG4U4fteH45GV9WQroxvzp/gP/Qf8Uen/&#xA;ALs+o8/V/wAj1OPpf7Hrmx7O/NerwPK+XnXP4uFrfA28X4c/0KHlP/lXNbv/AA76VaJ9b4+t0q3C&#xA;vq+9cs135z0+NfWuX6GGl/Lb+HXnz/SjfNH+Df0Uv6f9P9HeovHl6nHnQ8f7vfpXKdF+Z8T9zfHX&#xA;l+lt1Xg8H7z6Uo8rf8qq/TUP+H/S/SnF/R4evWnE8/t/D9muZet/P+GfGvg/zf0OPpfynGPDri+L&#xA;OG48Ty+zTf5ZpA7QoaL9Hf7q40r+zWlfoyyXH1axw9EVlTY7FUM31D1mrx9X9vxy0cdeTD035q6+&#xA;n6YpTh2r0/HKyyC4Upt07YEqFx9T5p6/Hn+xy6/RlkOKtmEuHqhNS/w99T/3K/VfqfMf72cPT50N&#xA;P734eVK5GV9WQromK8N+FOu9PHIpWXHoen+/p6dd+XSuShd7MZVW6yD6pUelStNqV6YZcXVRXRdP&#xA;9U+H6x6ffj6lPppXIMlRuPE8vs03+WEKUNF+jv8AdXGlf2a0r9GWS4+rWOHoisqbHYqhW/R/rNXj&#xA;6v7fj9OW+uvJh6bRKceA4fZ7ZWWQbwJf/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <xmpMM:InstanceID>uuid:dbc16444-e1d4-460a-9028-c2112fea17cb</xmpMM:InstanceID>
+         <xmpMM:DocumentID>xmp.did:190ddeba-a139-4b41-9eb1-38d2c6e9d89e</xmpMM:DocumentID>
+         <xmpMM:OriginalDocumentID>uuid:5D20892493BFDB11914A8590D31508C8</xmpMM:OriginalDocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>uuid:6a4942c9-3310-7041-adb4-7d5533119c30</stRef:instanceID>
+            <stRef:documentID>xmp.did:0f4b7733-6de2-4a28-957b-2e89a11eee94</stRef:documentID>
+            <stRef:originalDocumentID>uuid:5D20892493BFDB11914A8590D31508C8</stRef:originalDocumentID>
+            <stRef:renditionClass>proof:pdf</stRef:renditionClass>
+         </xmpMM:DerivedFrom>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:d00941e1-6ad2-4e14-878c-be0b9de829c7</stEvt:instanceID>
+                  <stEvt:when>2018-11-06T11:14:15-05:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:190ddeba-a139-4b41-9eb1-38d2c6e9d89e</stEvt:instanceID>
+                  <stEvt:when>2019-01-29T13:29:51-05:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <illustrator:StartupProfile>Print</illustrator:StartupProfile>
+         <xmpTPg:HasVisibleOverprint>True</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:HasVisibleTransparency>True</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>841.890000</stDim:w>
+            <stDim:h>595.280000</stDim:h>
+            <stDim:unit>Points</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:Fonts>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>MyriadPro-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Myriad Pro</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 2.106;PS 2.000;hotconv 1.0.70;makeotf.lib2.5.58329</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>MyriadPro-Regular.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Light</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Light</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.5474.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.175.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Medium</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Medium</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.25136.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Semibold</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Semibold</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.173.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Bold</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Bold</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.139.otf</stFnt:fontFileName>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpTPg:Fonts>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Magenta</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+               <rdf:li>Black</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Default Swatch Group</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>White</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>Black</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>35</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>32</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Red</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Yellow</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Green</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>166</xmpG:green>
+                           <xmpG:blue>81</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Cyan</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>174</xmpG:green>
+                           <xmpG:blue>239</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Blue</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>46</xmpG:red>
+                           <xmpG:green>49</xmpG:green>
+                           <xmpG:blue>146</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Magenta</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>236</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>140</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=15 M=100 Y=90 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>190</xmpG:red>
+                           <xmpG:green>30</xmpG:green>
+                           <xmpG:blue>45</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=90 Y=85 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>239</xmpG:red>
+                           <xmpG:green>65</xmpG:green>
+                           <xmpG:blue>54</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=80 Y=95 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>90</xmpG:green>
+                           <xmpG:blue>41</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=50 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>247</xmpG:red>
+                           <xmpG:green>148</xmpG:green>
+                           <xmpG:blue>29</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=35 Y=85 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>251</xmpG:red>
+                           <xmpG:green>176</xmpG:green>
+                           <xmpG:blue>64</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=5 M=0 Y=90 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>249</xmpG:red>
+                           <xmpG:green>237</xmpG:green>
+                           <xmpG:blue>50</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=20 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>215</xmpG:red>
+                           <xmpG:green>223</xmpG:green>
+                           <xmpG:blue>35</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>141</xmpG:red>
+                           <xmpG:green>198</xmpG:green>
+                           <xmpG:blue>63</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>57</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>74</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=10 Y=100 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>148</xmpG:green>
+                           <xmpG:blue>68</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=90 M=30 Y=95 K=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>104</xmpG:green>
+                           <xmpG:blue>56</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=0 Y=75 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>43</xmpG:red>
+                           <xmpG:green>182</xmpG:green>
+                           <xmpG:blue>115</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=80 M=10 Y=45 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>167</xmpG:green>
+                           <xmpG:blue>157</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=70 M=15 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>39</xmpG:red>
+                           <xmpG:green>170</xmpG:green>
+                           <xmpG:blue>225</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=50 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>27</xmpG:red>
+                           <xmpG:green>117</xmpG:green>
+                           <xmpG:blue>188</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=95 Y=5 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>43</xmpG:red>
+                           <xmpG:green>57</xmpG:green>
+                           <xmpG:blue>144</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=100 Y=25 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>38</xmpG:red>
+                           <xmpG:green>34</xmpG:green>
+                           <xmpG:blue>98</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=100 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>102</xmpG:red>
+                           <xmpG:green>45</xmpG:green>
+                           <xmpG:blue>145</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=100 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>146</xmpG:red>
+                           <xmpG:green>39</xmpG:green>
+                           <xmpG:blue>143</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=35 M=100 Y=35 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>158</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>99</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=10 M=100 Y=50 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>218</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>92</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=95 Y=20 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>238</xmpG:red>
+                           <xmpG:green>42</xmpG:green>
+                           <xmpG:blue>123</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=25 M=25 Y=40 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>194</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>155</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=45 Y=50 K=5</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>155</xmpG:red>
+                           <xmpG:green>133</xmpG:green>
+                           <xmpG:blue>121</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=50 Y=60 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>114</xmpG:red>
+                           <xmpG:green>102</xmpG:green>
+                           <xmpG:blue>88</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=55 M=60 Y=65 K=40</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>89</xmpG:red>
+                           <xmpG:green>74</xmpG:green>
+                           <xmpG:blue>66</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=25 M=40 Y=65 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>196</xmpG:red>
+                           <xmpG:green>154</xmpG:green>
+                           <xmpG:blue>108</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=30 M=50 Y=75 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>169</xmpG:red>
+                           <xmpG:green>124</xmpG:green>
+                           <xmpG:blue>80</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=35 M=60 Y=80 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>139</xmpG:red>
+                           <xmpG:green>94</xmpG:green>
+                           <xmpG:blue>60</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=65 Y=90 K=35</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>117</xmpG:red>
+                           <xmpG:green>76</xmpG:green>
+                           <xmpG:blue>41</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=70 Y=100 K=50</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>96</xmpG:red>
+                           <xmpG:green>57</xmpG:green>
+                           <xmpG:blue>19</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=70 Y=80 K=70</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>60</xmpG:red>
+                           <xmpG:green>36</xmpG:green>
+                           <xmpG:blue>21</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>2d8eff</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>45</xmpG:red>
+                           <xmpG:green>142</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=14 G=50 B=79</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>14</xmpG:red>
+                           <xmpG:green>50</xmpG:green>
+                           <xmpG:blue>79</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=243 G=248 B=255</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>243</xmpG:red>
+                           <xmpG:green>248</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=73 G=73 B=73</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>73</xmpG:red>
+                           <xmpG:green>73</xmpG:green>
+                           <xmpG:blue>73</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=250 G=251 B=252</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>250</xmpG:red>
+                           <xmpG:green>251</xmpG:green>
+                           <xmpG:blue>252</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=217 G=234 B=242</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>217</xmpG:red>
+                           <xmpG:green>234</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Grays</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=100</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>35</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>32</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=90</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>65</xmpG:red>
+                           <xmpG:green>64</xmpG:green>
+                           <xmpG:blue>66</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=80</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>88</xmpG:red>
+                           <xmpG:green>89</xmpG:green>
+                           <xmpG:blue>91</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=70</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>109</xmpG:red>
+                           <xmpG:green>110</xmpG:green>
+                           <xmpG:blue>113</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=60</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>128</xmpG:red>
+                           <xmpG:green>130</xmpG:green>
+                           <xmpG:blue>133</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=50</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>147</xmpG:red>
+                           <xmpG:green>149</xmpG:green>
+                           <xmpG:blue>152</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=40</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>167</xmpG:red>
+                           <xmpG:green>169</xmpG:green>
+                           <xmpG:blue>172</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>188</xmpG:red>
+                           <xmpG:green>190</xmpG:green>
+                           <xmpG:blue>192</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=20</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>209</xmpG:red>
+                           <xmpG:green>211</xmpG:green>
+                           <xmpG:blue>212</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>230</xmpG:red>
+                           <xmpG:green>231</xmpG:green>
+                           <xmpG:blue>232</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=5</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Brights</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=100 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=75 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>242</xmpG:red>
+                           <xmpG:green>101</xmpG:green>
+                           <xmpG:blue>34</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=10 Y=95 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>222</xmpG:green>
+                           <xmpG:blue>23</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=10 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>161</xmpG:green>
+                           <xmpG:blue>75</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=90 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>33</xmpG:red>
+                           <xmpG:green>64</xmpG:green>
+                           <xmpG:blue>154</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=60 M=90 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>127</xmpG:red>
+                           <xmpG:green>63</xmpG:green>
+                           <xmpG:blue>152</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+         <pdf:Producer>Adobe PDF library 15.00</pdf:Producer>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+endstreamendobj5 0 obj<</ArtBox[9.0 9.0 850.355 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 282 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 24 0 R/LastModified(D:20240626145315-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 133 0 R/C0_1 271 0 R/C0_2 136 0 R/T1_0 115 0 R/T1_1 119 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 27 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj6 0 obj<</ArtBox[9.0 9.0 797.17 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 274 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 29 0 R/LastModified(D:20240626145328-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 131 0 R/C0_1 132 0 R/C0_2 272 0 R/T1_0 116 0 R/T1_1 115 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 30 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj7 0 obj<</ArtBox[9.0 9.0 771.016 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 273 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 32 0 R/LastModified(D:20240626145331-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 26 0 R>>/Font<</C0_0 107 0 R/T1_0 16 0 R/T1_1 14 0 R/T1_2 17 0 R/T1_3 18 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 20 0 R>>>>/Thumb 33 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj95 0 obj<</CreationDate(D:20190129133010-05'00')/Creator(Adobe Illustrator CC 23.0 \(Macintosh\))/ModDate(D:20240626145348-07'00')/Producer(Adobe PDF library 15.00)/Title(Presearch - Brand Guidelines - 1.0.0)>>endobj271 0 obj<</BaseFont/XWWPFT+ProximaNova-Bold/DescendantFonts 283 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 284 0 R/Type/Font>>endobj272 0 obj<</BaseFont/FFVYED+ProximaNova-Regular/DescendantFonts 275 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 276 0 R/Type/Font>>endobj273 0 obj<</Filter/FlateDecode/Length 8073>>stream
+H‰lWIŽ$É¼ç+òãûrÕÐIô€‚4:T˜ÑÿÙB¬ž4ÐŒô »“4£ñ§¿ýüüé¯?§çŸþüóó‘®×ÿ÷úÌÏß~yüô—¤ç/ÿ{”Õžûù*³?ûîWYÏßþõø÷ã×GzŽ\i¯¾¯…%aâç>ÿ‡y8ì}Úá¯üLø—Ÿ#]­beïõª¹•çÇ·ùö(×XOŸz¥Yž¯t¥ºŸõjEFÞÆèFóù…{šs®g»òÈÏW¾*Ö‡Qp……aÂq­Ïøª^]îüÂX9ËcÃOíJ‹ërÛ4ÊœÏr­óøÇãçã?4ö•öÆâ›ŸØ5µvÌví
+ëÚ	Ñ¼&ï±®žü¥ÒÌe>§núš×À=&®6^ëî–i8\×\pØ¯ŽwØCçžpþñØWºîBn6L†bÃímd-“‘¯Òø‹¾IWÕ7	Næ²´-~Á*l±´6_ñÁ	â2ðâã1‘³‰U`ÀŸ/Úu÷‚P3ß5|§Ÿ“¶ŸÍÏ+m‡ùyÌWÆßVñ"}yþÊñï_ÊkvT~é!F¼ïêz•|¥ÞT_¯R`<òaç‚‹®Zn+ãà¼ö±ãÏçûEu.í¦àV©ýÛb‰øéó÷e„e×ñ}öùñ°éÿ?ÃòÁì!é5xÇgüùv¿@"‰àÏ÷¸žÄo‡³rŠü…£¬2¾Ö¼^û«vÕyL„sìã(oóñ°{}s²Xì£ ¾p{
+ƒç÷þñ‚ÇõùâÅ}?yúÝm?”ï4EuÐˆO¹Zj±O0Ô)ˆ¼^£P{SQ!r
+‹¼¯©ºù]™yM€‹|t—ôHÈE—¯LÚÕ¶³j‡1D©ÒFjŠÿTƒ¹˜‹Fgm §cï0QÞŸ#Âvê"ÚAD6™"‡”î®«±8ŠÝÉšàa%?ãFuü`ƒ†zbeq9òƒMPÛl»'qTš²Ò+­¼!Cu^}ˆ6ƒU*#šxàüvUTÍ»mž™ÂÈ•Å½²î¿ŸvØ$–$
+e±üÉè0Z;‚¸ÅJLë³NáDFÛã½1@ÚÕ$­HÙ+6Ë_`mØ=ª“i®¼Ú¦Þ¦ ZŠ¸§ßS&!54£ÞúUÒÿµ¸1lt±·ª²ç“xÝ&$Õ`Ä(¼sN‚¶£QVwåÅÊ©[]aWGŒö»¶qF{’\ˆQnýÚEŸŠ“—‡  ¼Ö®"µáŠeÿÒº>³ ÑøÛPÑ§œßFËGëDì.Ç#òK²>N#À&]•·è82Îˆ‘œ°keºˆ$›‘L|4ït£÷)ˆÖ¤9«*‚Èoˆ€*:MRÈVÇsˆíƒ‰fu«N™+PÍ@KWêéÎÇw¥¾K‹œôÃÛ¸æ.NNS“¤ù€‘×É Õ@wŠöªìó^Bàd-wòñJ…›&ygâ
+|NÔ8Pºb_;ˆ¢±ÿ¦iñÑyã^n£¨/i¡M±œèwÛb¡*žÇaîŸ&œÀ yalÝäyðû&Æ'ïØXî¥DÆ×¥*bLVwÙš¬ì<­”“Q:¯ Y÷Ë„LYX›óBB}ñ4†¯)Œ8{	Êds…ÔÝ­"óIð¡Âû“Yºƒ‚8[·
+,©uÞV0‹Ãƒ–›LZzŸÒ™)EÉƒËD­×åÏØáÚÜË`P-QA†ý
+tÄ—(R2¸ æHÈ¨Xèç×,n|‘ñ"ÉÑfà‚ò±WWËRµ»rOƒ=¢Ï™íOÆdø–©žß"²Ä¾»2sªB¢âH”R•¦ ÔvZÜÌ.õ„>÷:]ò03Û7·èMI¦?‰•`VkÌÚú–QDxq þ½zX®@ÇIbT5N%¿kEF·×´*®äàÐcÈvÓÚ.À°íVêwÍö£ÍÓ3‡ŒS?¼`ó¬¶ÛÒðÂqŠmÃµG&~¬o	Ãï÷ùËŽújBóãôŒfŠEF¦Òfx«¢ú{™ŽiûcQoHfMë»¸&³³"É&«‰íš[džÀä<‡Y– šöA»rÐ­d«‹±8O­ßÐ“~TU§YxL‹„ÚöÍJ%Fâ`Ë–<tù#
+n¾0Ÿ6!¯Çô%XôÚÞUJ\­[P2{ò»ù“¡ÖJ›â÷¢hüPRsTßjwlEtÂP4íº{Z¼†^êa0õM¢4¨CÙŒ²1è¾…Ib¡L²…nTˆæeJ‘ôQ<f–-) ‘a¬¥ÚLúeIð³ÇÝå8QFR¢Þ½ªslw™R)vŽ¹‘Ç¨ƒrŠzî“}*ú6æƒE»qcË–<!hGç¹Ör¯Êãl‘çu7(2–J3Â£wŒ/¬-ÁÚ.ë¹n¶#íÚz~Áx9u(<f¡YˆYæ®‘bhÆ›	¶›×¨#fŠýJuHŒÇ€ÌŒ}4E»˜z¡.ÞnãeÝ¯•a‹üÝëž\( âòV¹š‡Ê=^¸kÂjìjEã¢ŽšVw³¯GQ::w‹5¦ˆ‘cÂ}‰`V¶Ì~,.3ðæáÑÜ¬\–â5O‚½™«U)E§cänª´®&P•Fêb²ct…5j°cÜ"Ú›»0»˜ÔÓ=Ûì~Ô#Q\ŽÁ…b7
+hÂSÎ1ÔWÝå?¡…üÝç1Ï¬lhó5éê;„ÿÐ"ÂO0R 4”-_è»x ,ù–g‡¶uW—…`—ÆûuÜ–Ü.pLÏ•¬¶{òa¥[U’rXÃRB%iâWäutCOÉoóVgæÄ]­„ VM¤!ªÝæ€n6nÓSŽÓs8Þ&Ëû“æNwNP¿™a&¶Ã¸Ñj3¤¹¿ºÕÓÐ,RÖðÜœÜfõì	!ÇyÝ(„ ^…º[·æ-§µO&¸e‡Þ$¿]n5h'¬z¾åšñ(i½˜°(D(©ÌÄ&IÉðyY•ì.¤Ÿ—N´êÓÄó‡}m”It{&i#´fOèFµƒ¸Ñ†0ê¾Ñc3x#=ëhÖ£CrŠƒÿêòÆÈFÕ÷âYŠŸš‡,ú3¨®pòd£—r.šdÙÂ Ì³î.gû0Tî8¶¹ÎÎÂFÞ‘-7wîež\rñSà+ò‘c!rÓîÄš7%rd”E<Þ@
+Z1Vâ &6óš„:ýñànî‡êxs€.ù‡ÚºÑ3\÷ñ³Ùë‰Ü2R=˜`$ðKÄéžöLT¦ŸË:Ð³ŒËÄýÞ úæW#»©ºwSõí@ÅòBÆŠž¤´€Ÿ<œOÔjáÐUr˜M³œã"Ëç”9G
+/@/GÓþ¯A÷lemÏæ%=f‡žÎT€nS³aèÞYmÎíñà8jµâ¨a‚ëš%6oxw1‹¬˜I¢ý» îÞìˆ)×ÎÃ×áFvõöËUïpúŒ¯Èæ}Ð0mœá{ñ.Y˜Lª •Ö›u5g:ŠkT'Ïí#v¡ØÄSÌ°„	ÐsQ¾%ÒáALï]ÈÀ“¬HR–úî‡>±@ì´×CÀJtLfÈ®1ÂF!´3Íšxpá1HI})Eûšý^–|Ÿ«²×)Cé ÓŠ©5xçÝ¦9jdË<êB£.%W-äãŠ'ƒÿÓ^m»qGô}¿bÉ K÷ý,Å$€l#0dj)1ZqeŠ
+’¿OSÕ=C­lØò qj¶§/Õu.eŽQ³¡U‡DQu„l5°‘©eV“¨Éšæop3<gÉ Wõk
+ÔØbÓ)AèDf5JçTh¬bí\[S¤x£ä:zV-+NêÍô–^¸¨õŸ6q`ƒ0âA]ë, –U.2“ú„¸($TžrühXV\_sèú$ó©C9ú3ÇäS(5†ek[§‡žÞÆÀSÞ¦ÅQó1úJµ†D[«aZkIQÕ¾Õ…¡Ð„¡p¬7O#Vhžvôi&›WYBðUƒÊ2~ÉÍ¶ ˜\xŸà/½YË¨Í R‡F”‚¡»å£J¯=Ø}hÆ´ûPiQNS&„~ `H—{ÕAycraàÔ/q{A8Ö	9:ÕÚgz4 ¬×’-<p/%âcX³uùBí†Š¡ÝŒ¹=ÉÙ+:ZÝ¾v VªG• Ç*—/óGNŒã#ëÑ	Gdv}ÞêóH´Fú™Žf¯¨/´“Åz0èjÕº+#m/â^Žš¡XY&ƒÚ‚€$¯=äÞX~öMdâtÅ9ùCÝJwmã0Dím˜óžvFÒ±—ò ^ë”._ÌâÜÈSNM=Xˆ —´ºRÛì>hCÕ…5µú- “é³Tá¡xÏÓI±:ó>ê >O«ði”Sþ?ŒTØ©þ‹Œ”ÿ	#Õ~½‘Š?o¤žúû_@èá×ú¤óÿÕ¦åMCé'êù”øŒ<·öË÷Õ~¡¼Ý¬óÙ~a¾­ýN7ö+ç­ýrÏýWª–ÒjÀØg¬çœç_˜dfkÀjØ°¾u`-mXŽyãÀR[î`ëÀJY-Xr[VÓÖƒ	e­¬·Õƒ±—\=„yãÁªëÖúÆƒ•¾z0³‰_ô`)¤gL]’y°’6¬oL˜~½š0ÙëjÂz~fÂš_MXˆ–ãÖƒÕ2=Åaz°Òžy0ìiz°ê7Leiz°7,ÕÕ„Ám<XÒžòs†u×ÊóÎ*Ý½8 i²µ_ßì¾zé¾æsËán'~
+Dœ!¹u9¼ÞýÖ‰q®dçª“Aâ7	¢“†Nâ?H,a‘÷ÕÛXù[‹ŽñRQ/^nþ:¼ÿÝáŸB«¢Ëá÷X%}­³c–âìË¤£ù·à‹o»¯çO·oÿöáûÃñßOß¼¾Zþò­ž+P‚×ÿq¶ƒÇÙp4Y‰/XÂ!…/bïáEeïwW_/OËùn¹=¿ÿp~8><}Äã÷Ç×Ëµmö&c·WOç7Ç§·ÇÇåé¼Ü>_=	—O÷?~:.§óù¿8üfwõêáõrw<ž03Æ|ûxüxüøêñöíòÃ£üxÃ©/®D¶íuÛÁqÛò'5±|°A@
+ÐÊ¶¿»’"[×^Žsu>ŸÞÝ?]ÿãð§~d3K@ÒHiG)Ž*u›“ðgo‘ÍÖþx{~°3‘àÌß]ýùZ
+÷êüæüôŸG[„ÄÅ”¼<ŸÎŸ?Î‚~t¸nn¹’î^ÝÎá‚cþþâÕí»ë ä¶\½y<zx=Æ¥¤m/Åy%w‚$þë|o3I-ü(C‹¤¶¥å~ÃŽRÃÇãîïËÃefW¡nEcJ=t/´1…^p)ÄáaÂæ%„8Ê{¦60Wkóêr-BÚUÀsZ ÂNók¡L‹Ç„äBS[‰VYª*ï%úz%ºÐàê-¸ÕTáñ$Žõ`%ßhxÚåñXn¼ÓÀ9˜ïÕ{çÐi\­Œ±nÓ9:E©«R5q(FEXUî²6’M+¦c’h¯m‘ÈùWâÜŠRzÃ¯gƒ0„‰Æö¢cË'‘cù¥ðO~Ô½Êšµ@àSGGx £•‚¥
+×*Äìº{Ôž¥"Di(í·h¦GT!Ø£H&¨ìa„´ktÑÞ7ó±nóü¹£”æEÄ[Œ@mcÔÊ`yv5šÞiJÄ¡…6{D:}ÇˆõÏi}Ñ™Â1OtT![Á"Ô‹=ŠzPw-Ôémt^êBþ²H7§S8k÷1°)µ?ïçôU>ÑîÛ1‚b	÷Q<{‰£ì÷ØKO[ðµþ9ášÚˆ*ë×æ±@W¡ƒÐ–:P UèŽ–ÄôE'² »×Õí6«»³ótœè³³ª¾–à¸HDv/6$[FøènSUÈ'Á5§,Xséyó†RÆu0Œl„RîÐC6üâàRj`›iƒc!»¶j´Ið$¢hé"Ó‘þXeR™Œ“Á'ô­ÁYÂÏœçiÞÑÍÕJ|¡“ž>›;”E š§´ØƒFQ; IN¸x±÷EÊÐòèå_¶8;Ú¥=×ôžŒÑ@Œ2u)}¦ñ‡WûÈV´°sñ Lc„qB®ñ!8°zXº»‹A£W–Í×mB"JUè°dH8\ ÃÃ2G´‰89X¿Äumiÿ:‰³ÜÛéår,c"°ÁÁ_Æ˜2­¡nµGrµŸ‘•úÀ&¤1÷–g…Ùä È#å­F$¯—0®BÊÄƒš´Ì‰Ê%üÔõAó!öE€=²•À¥¢=ÔS:e¦’Î­Ö¥Ï U	ù-Í8ËÏÑëË^Yë¸µFê†T{m…ýSÜ”q
+Íî;µb8A„þC°ŽÍ¨úQ?Ñ7·Î+z‚¾Ú3Z&îÕ{t»]ûµ.%%Ûwì­ª7ÑÙ+Ò4´zc:î¿ËE/\ÚÐŒBU «?U°/j…:+·)pí¸&Ô-ÇUÙ€l´dóÙ!´ød‘m+ŒzdÏZ£V£^Y´Ø®	šÒ¸¤5ŒËh)s¡¢4‚aV%±CÍžá´aÇ™‰5ÑÔ\ˆq JJD+L)=nâ=C¨}ñ3R°éPÄF$$°fÉ\WàRXöjþ°ØŠ:ÑðÍÝ+KÛÑÎ8w—¤¡ËZ¸§Ý N”é"q°*T¶ñ‘dd¿ÒöFÓäýý¨Sf‰´:Fï§ì˜Y‹Då^Ã‹ŽZA)2Ž~\ÿ¤OýB±EY±ù’ã¯1‘‚:}¢F“‰°—ˆm&2æM+âèe aa‰u†V˜°“9˜I¼T**,1ÚN÷†ûNZ,$•‡¡a5l"’zÑ&·hMc¸üP»æ½™˜ád
+oÙøf ÞÄpÞä SÌ!ãò,ä©[^_ŒT£â#/:/“°3°ÜØ`AßÔ@ÇN©¼ƒªnÌBtžâKrG G cPgÄQ”¡• L_¾ÈûU>«rr•r89åÊûR>(Ù´q³Vê³0rRJãÅ
+6àÿ‘#-¨‰a©3ÖYOd‹PÚ^O^Q×J¹x	Î;`U_Ö[wÔ]5—Šùi‹,ÇvS5-{¯ŽA&R ß¶P*Çq–`äõÂþg”Ì&ù$£7ŠêJœÉ„RàºZUxãNoç%<CrÝdŒuP ™F`Ùóø‰]I‡bV°¡Þ,FAWæÈ»2©J±ËêOQ›WÅ,Ñ$
+ƒÄÊ#Jþ“f …ž¦i˜¨ÐV«„ÚtmˆÐ†/*½F2h¶Áˆ•
+‡›@ï
+[/nÂ««-ððzËPÚäÅÔç.Ã€%¨ú[Tq±VBŠÀ÷*óœ,’õfÆEÏ¤$©Är»ÓK¦~ù!¥ÌÉþõ™ûNláV¤Þ´-´¾iª#Œ¸rT™=Æ±* Ç2}ˆD­÷Q
+æÒ•0 LLj4ÑRë!Í#íæjËxÎuŒ’äÒ­i¤¢p®Q¨LM£àÓPª«Yt#&ÿ¥½Üšã&‚(ü®_¡*^ì*6H#Fó;6×@–{Q”q¬íà„\øõôéÓ=Å
+ ÊqË»š™žÓ§¿&5ÂPÕGºý=:5ÂûW¥oßÊ’oàP7”Ç„8 c@L’¦y2ú€ÿzSµGBÛ¡õ#(,,H•àMâh#ÈšõÊH],YÇÑæöÝ·ˆå‚ï6[šb²i&;"TÞ@zìÚÁ@­½'ÌÏ/á@MIÃ@!LGxÓò6¶®ËHí9„å¯’§ÀN‹í°;qEíšù{OÌVä;M:*$eÔ‰Ÿ¦“ÚQÐ³·q8°2˜j$SÔ¹ÿ~Ú˜ÓQ¿1Ç%˜cÁ„ÓÆ`ŠßÛyè#¦­èil+¸ÒC³œ'“ýI•k§×¬”æ!ÒãU%5dùØNk½¶¶¡ôlÔRÕñÊ!÷V¶î7Y ­9+ÒÜ².`ìÇvÉ9FTëIavrØÐÑ6>e*®´µyk±m¸±Ó,}iRè;‚›f—ˆ$3aDù¡ì=¢Œ)sÄtoÿ¦Ã—¾¶Un”´?v!u³N³¨»·îÂŽÂ'ËÛ¹Qc¹÷¬HÖ‚@ÎÌy-æ–k‹
+øù_9Óê8‘ØòrÝt4Z
+dÛ«Ãú($‹-N†VaÂDäó{[ÔõõíY|£Ÿ¨o:}’«T™E~aâåì!î`ñ†./‘ªˆ@,ïqòç()¥™ó`1· ú–fz»R5n®‡«Ó‘6ªª!ðq!Ç´¹àmŒŒjüÃÚ¢i˜x—–-äf±’Zôº±
+7Ó‹<2bQi‹þW{¥tn 4Âòƒ?©KË&ô	À¸Ý:åïUHÊ°J³=tÖˆÆ MU‡öLòÛ¤ši?¯ÃøE#{G¹š	¦ëDÖ¤ !z;PLÔ²õ Ð>]Ž–Ã)oJæ“ 9ö-‚,HÐ—‹pð6H-ð2±Àrô¬€ï÷ƒ®tG¼]¹>m»x©ªgj½uÈ=)Ú¦1µÁ£0eè-ê ¬±Qœ5ò‡;›'Ø¥ä^ò­¤+‡‘w3bŽÀŸ9NšXY3˜dœ[+a®YÚ!hÎop¬€RÉµ1'ßj–Ñµeh”LôÕiB"ä;âó…0#	\ÍÉºH‹ ð`Êr™Œ‘PNêž˜8æ'‰²Ò±S}ÒyŠµåk1:ml„°˜¾±QP¼Âª¥™Y#î³Âjˆ©Ð¿17wÜ{ÝÔ)ŸqõÀš,~€’X™¾aÑ¹$G †%MÊæ£ð?±†]c(hS¤#ÍÈ8ÛÜQÕ‹;­1ÑH°¦<Y`AMBRæães
+˜5{š(MäP°}dÃ›¥¨šJtÚ[l (/š¡:=¦'„€íˆ‘¤RLGh!*,Ú¢º9¾(3Ž£%]»“O¨Ñ]LP¦cmd›b+³:„Å»*îû¹Š¹X‰­&•7ÍKêª¸‚t¶äØn‚•·r‚7mR0V´#æ:F ÔU‘šŠEmî¼ñú ïZêcRzWˆ7¦·JT'‘TëXåYp2§ÌlyOA7©†‘ò`W°’wñF	1ÐZ•ÓS?ÇÒïåZCOwDNIVÌÕ«çR'cvÉ”bŸ­Õp·ü=¨ãòáVZ¦ŒJ˜HßDçjè®N‡"WU­Ú³Ñ™î0Ö"-ˆ´ž#‹£„ndñÎcü“úPåìš'àÈ‘yS-±]ãM ½ÙÄ^Sf)vÓŽµ6Ú±£Yñ°‹ YÆirÈû;­
+œÒœœ)ÐêDŠ]Êú”¿{Âñkü4¦×hOt'xMpªrr0Ž«.äJ1L²ÙQÊiŒR:CW1ƒë¾”sÒLèÔ6Ð^U :_èôgVB"0k
+“ˆJšó­»†ž¯yz5²¾¢~ñF\*@¨‡bÆÈ§ "?§1•‚£I©Æúy(Û·UˆºCÖCŸ=€Š5¤bw]3Cjº3|"|¼‘Ö$Ÿ‰‚æ×£ØX¡X_±Øt#[ÁX¨`l¨`,ý0Öÿ+ëÇàãÁ}þ¬Ä+ŸoõùðÏ}^‰oª‰/¿•ø¦¿%>l,/Ž‰ÃÒÍZk”Ã°è(ÕwEþÊi|-Êñ…5Ê¡z”CýV(Ç¡ÌQŽØTP.¥
+å°Ãå‚F†riªPnè—¢]¤ °¥B¹qêW(7†¡F9èªB9ÜÊ
+å §åòT£Ü€Ã×(‡né(7†¼ œN¶ÊÁ7*”Ód,(G¿7”K]Z¡\ˆó
+åÆ
+åÂ°"¹)5ÉI-8Éi–*’3Ê&É©c:ÈÅ.¯@ÎØ–§Þå§g¬8.å…ã þ…ãà«Ç).;Ç)Ô:Çev/ç85Aç8USá8Š³p\Ó€–H½aUûl:÷›ƒmóÞ¶ÿ¹}Üð°ÛSuUüöRn”þ9µcŠÀbidQÜ&HålÏšïönÞ9:~ÿƒ?úø“»Ÿ~vïþƒÏ÷§voûÅ—_}ýÍ·ûßo?’ƒçŽ´&í~û°Ù;ùñôá£Ç?ýüä—_wgçO»|öü÷/_½þcû‹˜2Öí¸n'Æ-‰‹’¥ ²œ;_÷øâüy»iï]^ì’¿vïÕ“³“öÓ‹'ºæÑV¼¿k'™xÙåê D†—š¯Ús9nî1:fpM{ùS“\êwgƒ6¢,ßáã™+IKŒz:…~	ù,È]µóAåÖƒùÄ/eã{ïÝ>ŽqÐ›ìQ•{Ceê–ŸÞ‡RÚ—m“PwÝuû>°}ë–l³vÙË>§$Q¯ÒŠÄu£ÇúßM7*iÔ\Î*gé²Ú4Î*Ø·æ³ÚC‡=È-×{øN6±/>¹wûøàøZ*zŒ8Iph’/ŒüøáÅÙÙïçOž¿Þ—šÙ{·ÝîKåí]žœ?{zrùèüÔŸß»|òâD¢›+z¯V§F“Ž2þõéÄë:QÀ #J3þ¿y†û„åA+¹Þ`q›Å$Öwæ£ÿI‹W7up%+®»õ¦Vº;º{Ø6
+0 2;p‰
+endstreamendobj274 0 obj<</Filter/FlateDecode/Length 4321>>stream
+H‰lWIŠ-ÉÜ¿Sä^vÌÃV-ÐJ¡…PhXTZº?È¬ê¿ÒóEz„fnñÃ_~¼~øóéúÃ¼^éÞy]ø¿×+_ÿý×ë‡?ý-]ÿúß«¬víë]f¿úîwY×ÿñúçëçWºF®´Wß÷Â’0ñóß¯ÿÀaž{Ÿvøó+_	ÿò5ÒÝjiWïõ®¹•ëã§ùéUîíÒõùªwšåz§;Õ}Õ»y7£wmÌë7þÂœs]íÎ#_ï|W¬£à Ã„ãZ¯øªÞ]îüÂX9ËcãÂv§Å…¹ó¹Ìy•{Ç8?_ÿ¦±ï´7Bð¶>±ijí˜íÞÖ½’yO†±îžÜœ¤ÒÌe^S¾ç=ÆDd8êÀ‰±n!´L«Àáºç‚Ã~w¼Ã>ö„÷×¾+ˆ P›“©ØðûYËdä»4þRôªo¼"Íeiß‰ä`YØ–‹ó½‘œ»¢nxóñš¨ÚDÎ*Ž0àláy1ÖàRÍ2L|Öðòpí^rÁ³ùùãõf§­0?ùÎøÛ*^¤oÏÿF;þõ[{ÍÎ.B{Uä	ºë]òºûë]
+ê‹G>ì\èªå±2ŽÍ°>¿^TÓn
+¢bJíß[ÄOŸ/¼/#,»ŽïÃ°Ï—Mÿÿ–fIÿx¬û¥?M¡ù
+I~½€ëIüv8«§Éß8Ê‚¿o=¯×þÃ¶]uéû8
+ÃÛ|¼lÆ1>‰–Í—}48nOaðüÞ?^ð¸>_¼xâ“§_Eû¡z ‘0ª€F~ÊÝR‹}‚¡NCä½ðz”«75õ7Â!§¤MšZ"`0ß™…M Ñu`ò# E_;¶Uq6À¹*2qX¦)üSç
+dÊèl uì&ú›û Å„vê"ÞA6™¢‡”Ê9áºÛäÑ‹ýÙœ bÕ?#&œë×6¨¨'6×>¿±	ëb»€q`÷$žJSVb¦•#£uÞ}ˆ8
+6ƒU*™#ñÈäî*¶ftHš?„‘+û{ee \`ÿÿA¾Éâ´µ6YFk9,yO™}©GëVd´=¾vP=7˜¯¨Ú;6Ë_`mØsª“mî¼ÚoL:_¦ ƒ ÁúKvÊd%Vª·~×ÿÞŒmÒEa» ãvÖ Í§
+I-£XØ‡‘9 ¡0èœÄ÷NGYÝM–»§²”è¸Âœ
+aIÚ_ý³tš“¬Àn¬§çú½›=×/E¨´µ«Sm¸m9Æ´®Ï,T4þ6[=åüe”±¼p´NÜîr<6u26^I4r¶éwn¤ãÔ8r1£aöËt?P6£ øhFÉ9‡¶ñ‚„AÓ€’ñòmhè•-Ñ1%4ùœeû`±ÙâHÖ‘rf»ÊOwÀÝV.ÇÆ®Äã"s€àlÜs—§iRÒŒŠÀÈë”`³ÊRÑV•SÐKžL°åNZf®„DÆKî™·šÆ¬Px}í ŠÆœ¦H'qöòE³ImŠèð+Ÿ¶ˆ¨VJ€qæ~ðiÆ	šÂÖ}:–É~Â0>`c·—Õ\—ª¸Q1 YMM\vªV¹gµ)¾Í†Î(¨ºÒ°6×¤šå©\¡@ÙÛ8P››£šü¤¶\ÛC…Ï'³tFGâlÝBT ¤Üù²‚X|ž³<djÈÒ;»UIÑAòàÑôuç3uˆºõƒõUdØï F|‰þìÒ­¹àÖè6ê<7Â
+Œ?Ü­X¶±>;Ý-ÆCÒ;ïS×`Àpôì©^‡æÜ®?å’áS=¿E^û­zf=æTAe‘ð¤:*M)PŠ¾áfvÉ§`ó¹×™’‡–·ÖîMÇV't’*Q¬¹0~Ÿ±'ämBdH.Ô)–Û/ÍæÊRK?-°Vt{Q«"êîÍCØYÛý¶ýJÿ®Ù~kCõôÌ{†:â÷^ptVÛm©¼Pqf•ƒ,üP?&RŒ Ú3ÔÙÞãŠÄÙø–G•ä2Š&ŒL­íü2­¿ê¸a4no¨fMë‰MæåêÛFì³]ó|Ì3ð—\èÝ¿A–=Àƒ&…›òvºµlÍ¾§DN ªNN³ì˜–˜Ùæ¤~Jìñ¹…éC÷BÀà¡Sù!“ ôÈ8ù¾}µ)µÊQ$Ì~¨ïaO¦Z+mŠ^<…‚Ã 7$æ¨Žj£Ï]Ú¦vB€êÀlM[êQK#Ì@¦¾I—Ç(«mcÔý&y…"ÉF‘çD×4\%ŽHþ¨.+Ëô@b}‰:×†Î½o¼Ëyj¨.êtÐœc{Ä”Jm°s\yhƒrøŠzîS|êù‘{œ+fÓè['°ã©ìè<×ZžUY÷8[dyÂÓ‰Œ¥ÎL…FsÝ¹+¸`|ãüÖuÁ˜XÏu³Y×ÖõLªãø¨CÝ±Í2Ä"!`î	†Q¼ym±
+Ã¨#.Ôú•Zk *3ö—"ª^èK
+x
+ò0B<ieØâ÷~®.µÖ½õC®æ!+ˆ¼ÏÐ„Õ8ÔŠ.Œ:jZÝ£¾ZMÎHODËZãAvÑ5v>˜j‘yTÞÛ5ø"âÑ|es_Î½cäø.Ø›ÉZ©é~T5‘ªBR“c.,e­ç'ŒpžÃœcOÏÕf£	ãr.½Q=Ÿ©Ï/C“ÕSþãRÈß}óÜõ‚m>¨&_ýâ¿ŒÙ ).HeË7þ.¾–|Å½æámÅê¾ð¤‚âu°xÌë×íöÜ{ØEéQU§§b¤ÙRA%jâWÔutƒOÅ×Ã{šw±†šYXCÇÒZñÄýçÛýµYhL_r\ Có6ÙáŸ4wzª‚ÎL4ñÆƒX›¡ÍýÕ£ †."eoÀÍÍo_÷ƒüœx¨ÆBAãfË@F
+L­}Ò0Á0;DÇ nßT˜>PA;©Õó#Úü‹/“–üKCÁ¤%s=Té#>1;“#Æ¢ôóåÄ‰V¡w‡"b£Ubä³PÉ5‡‚J7:F8DDê¨;""Èf°ÿFÖQ®G	žä%þ«çì.±1êQáÁ>KÓF#Ä4æºï
+/žœöÒÏEWY‡0Àó¬{ZÚ>—'‚‹w>úWëíòð—‘à‰æ›ƒ›.~
+gX‘&‘Ÿv(Ödº)”£¢lãñ&«ÀKÀäfn“\§?îå	èN 7(ÈßUØž'ÆvƒÚø‡H¬]o’à/—›ë_øLV¦ŸËbÐ7·‰§¾`	Nq?žÑÊ	®²aÜ[TÌOÐ}ð$¹üäáz¢WÛ‡î’Ãþ˜œåUžµN=¼îƒû'øì`ß¯,ï9¾¤) xÌu„›š‡à>yà€³Fá…ÔŠÅ9Ã-®›€SŸ9fÚ+€ËÿŒg—ŸnÕ<„:ßï7²£uðàØçó
+‡ŸAùºYÅœ{dLgH8,†’È¤öYi}‘®®ZàâÕ¹IrûÈã'6±ÁúJÆÛŒë«µcèt¸Ó{2ð$'’”C€yb¸Cò3XeŽËjkC|°ÑíÜhM;ˆxR_2Šö5÷½-û>_fïÓ„’Bÿ'½l{Û¶8þÞ@¾_ÊC“J%J@1¬É2 
+d˜Š½h†B±™X­-yzh–}úÝŸGJL³ ö"±O¦x¼ã=üŽ‹
+VWÕpÞ’‹0™IÄ#!ØƒG’Ú…qÆ°DXa8pÔèÜÁaWÙ¦ÈKè¬Ò3:ŸÃ‰¥æ;ƒ ±Bž!·t²ø€éÉ„C*žFæxÈmïdB>e-n¤Ã¾~q :d¦ýÜÊ¡â¢Ó¶›™/*EEéå} K;%xÙW.'Çv<"A*„9uUÌN(Ë\Îp‰÷C‹ž³ì›JÇ˜û¨O¨m£|„L‰âé6V¾¼ÚáV3-ÜpŠ#‘r÷¸ôÈæ'KfC›m…–3\“ƒtÎ~’¾- !øöfÃå½—95÷+¨ü®FPzié[2…fáN€2L´g>ÝçÜÏËÂÍŒ<Â‡˜Dm³àÃÚ¯ÜžìûËà)Çn+\Ñ¸¢w Zl±<å‰Œr¼°¾¾1-ÙãIš(0I®n18ï°`[ºÎs'î½xJñ‘¤rqÖÓsÖ_™Dw1Žõ€‘ËxâPÔ2Üyq÷"—+Ü:. p÷´j7†ydWRzÓm.’¶Xø¹Où»w4Kü¯¶Ã"?àYú èŽŒî\Â‹x’	™šQ=¥…´ x<6Ø?çoÆsƒ››lùúM©çÆ…ùM¦>r—1®ÔÊ¡­œ÷Ý¯l‰NŸÊ	ÝP‚²ë&¥§æØ'>.ø2À
+žedÊÇ—*‚óK©JÊ`Ž'XŽ)ç`AÙ¬g‘ÆØ¡0óÃ·Ž¥ršsü7Fég0J½£d€Qå‚Qé³%ÿEé—P”÷Êõ\Í^‹ù³µ¼|I-“¹šÒò—@Zö}HCè¹šÈ->W<CøJÊ¾’<cøÂ—0žo=|!Ù=}a¿¾§}aÌYèà—Ò©lá/;c,ü;gþ‚ý1™Íü¥eÀ_eðW¡BþÊÒ,à/U.ü…;ù+×€©8$0­BS2 0$š'0;G.†¾˜N +Ê Àòr0Çˆ€•€)f§ÀÊ, °\ x ã· Ëe `¼p0Ô&`2ø+S!é|æ¯‚[“ã/¶dæ¯<øK'qWšù«T)½ `,à/ÅãäÂ_¥§—Y@Ûy”ÊÜ8~[WDÍc UÑß­^_ÄŸ¨æÅ¢º]J¡gh·ZTÛÕ›˜X$&#âXÇô'I>'¹ !)”Hþ…dsz®·–>uÎkŠ¦ó‹à3Æó«ÏTP©+ˆêghQoñ„®©ã4CvÍcüæk³¦<#?ªH@‡<`©U¤xsû™ã•Ëjõºê¦ÍîÃñSeþ/·Í(Þ_±¤íÖË¸¢Jà
+x‚fÕQÚQ–%¢Ð*ûU;#.ºÃaj›ñáôjM¡u÷¦7[±þ³úÕšu–Á®èwS÷›¸lïšÖ¬aòï“Ê„UÊØª¤RI·L–Ò’TFïÚ±ï¶Óflºvý»ì‹-;§)æ„íðntÕ›×¢nEw4í+±5Cºê}óYã{z1îêQôæ¾î·ƒØxû¯OÄÁnL?ˆµ»Ò¦Œî›q'5Õ:¡ˆº/kJªÈ´ƒ¸ízÚÔ4½˜†úÎ¬©’Q©Œ^Ñæt†æf‚¹bìè‡„.š~¨Û­8öÝ¡³¿t·x]÷õH[Î¼ó)íþX«˜4‰Moê‘Ì¡ÅƒwS³5{2h ­ÅÎì¢žÆ]×[“§–¸—Ã“¹×'lðrÇÖÎ¨7G,kGÑM½¸éqFü‘–vÄú¦µ¸¯Ø|×Í0âë#¨úkº>!¯cùáXoF»Zý°ŠêÃMã-†rÁg³ÏœÃÙÞèÃÐ´wÎÈCÝ¡kÝl¦žLß?ØK¦ûì›nè‡#ÎpÓXö´xz7‘+ÍõÉVÜ<Ö<º×hñž£x$.ÊÞp~#9¿ÃŒÞÝŠ‡n»ú«!d±`Ô@hj:3n–[¥?½ïÏ¼9«‰³K*
+¤*ûDÍ™ËË÷bõ¯  ƒ¬Q
+endstreamendobj275 0 obj[277 0 R]endobj276 0 obj<</Filter/FlateDecode/Length 240>>stream
+H‰\PËjÃ0¼ë+ö˜‚œ„ædÁiÁ‡&¥n?@–ÖŽ –„,ü÷]I!….H0ÌƒÙåM{i­‰À?‚SFŒÕg·…Ðãh,Û@(ÿj’žq2wëqjíàX]ÿ$rŽa…ÍY»·Œß‚Æ`ì›ï¦ÛïïpB¡!@ã@AïÒ_å„À³m×jâM\wäùS|­áñ¾”QNãì¥Â íˆ¬®hÔo4‚¡ÕÿøcqõƒºËÔ/¯¤®ªÓQ$t:t)¨)¨$=<)“V‡gaµ„@]ó}rÉTÏX|žÐ;äJý
+0 ñuS
+endstreamendobj277 0 obj<</BaseFont/FFVYED+ProximaNova-Regular/CIDSystemInfo 278 0 R/DW 1000/FontDescriptor 279 0 R/Subtype/CIDFontType0/Type/Font/W[0[507]1 2 0 3 4 258 5[125 56]9 10 500 11[250 167 333 598 230]16 17 612 18[339 424 588 557 558 590 591 515 581 591]28 51 598 52 53 612 54[339 424 578 557 558 590 591 515 581 591 658 629 676 700 569 550 713 747 712 239 475 601 510 809 708 765 587 765 608 586 570 700 658 883 652 626 585 527]92 93 575 94[495 575 563]97 98 283 99[574 552]101 102 225 103[514 225 268 808 551 572]109 110 574 111[330 465 294 551 490 734 486 490 551 472 572 554 582 615 509 491 626 642 635 229 422 534 458 719 632 662 522 662 545 504 472 623 572 764 567 547 516]148 169 658 170 171 947 172[629]173 177 676 178[700 728 700]181 197 569 198[550]199 203 713 204 208 747 209[731]210 211 712 212 222 239 223[713 714 475 601]227 230 510 231[529]232 237 708 238 261 765 262[1105 587]264 266 608 267 272 586 273 274 672 275 279 570 280 297 700 298 301 883 302 309 626 310 312 585 313[728 587]315 336 527 337 338 889 339 360 575 361 362 936 363[575]364 368 495 369[644 577 575]372 388 563 389[858 566 835]392 393 509 394[797 509 551]397 399 792 400[835 283]402 406 574 407[554]408 409 552 410 421 225 422[451 450]424 425 225 426 427 514 428 429 225 430[291 307 287]433 434 268 435[293 307 299]438 444 551 445 468 572 469[962 574]471 473 330 474 479 465 480[557 587 283 294 313]485 487 294 488 505 551 506 509 734 510 517 490 518 525 551 526 528 472 529[572 574]531 552 572 553 554 821 555[554]556 560 582 561[615 626 615]564 580 509 581[491 720 949]584 588 626 589 593 642 594[655]595 596 635 597 607 229 608[650 651 422 534]612 614 458 615[472 481]617 622 632 623 646 662 647[953 522]649 651 545 652 657 504 658 659 597 660[1008]661 665 472 666 683 623 684 687 764 688 695 547 696 698 516 699[626 522 226]702 703 0 704[226]705 706 0 707[226 265]709 710 0 711[265 0 305]714 715 0 716[413 0 127]719 720 0 721[236 0 313]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[205 0 194]739 743 0 744[230 658 629 550]748 749 658 750[569 585 712 765 239 601 658 809 708 615 765 712 587 575 570 626 806 652 796]769 770 765 771[589 575 490 572 485 489 551 572 239 514 490]782 783 565 784[490 489 572 582 572 483 572 458 562 691 486 708 771 658 623 766 293 785 725 779 239 626 589 485 551]809 811 239 812 814 562 815[572 771 514]818 819 123 820[390]821 822 143 823[230 658 587 629 550 717]829 830 569 831[909 584]833 834 708 835[601 712 809 712 765 712 587 676 570 626 806 652 723 611 958 986 752 788 587 676 992 608 769 550 676 586]861 862 239 863[475]864 865 1060 866[785 601 626 696 751 909 708 601 658 806 527 575 574 540 436 561]882 883 563 884[708 485]886 887 552 888[514 552 671 552 572 552 574 495 402 490 683 486 552 541 783 798 610 712 522 516 767 547 554 436 516 465]914 916 225 917 918 849 919[554 514 490 544 575 465 574 708 455]928 929 551 930[514 490 552 551 808 541 560 808 816 610 522 767 572 436 561 552 402 768 590 743 561 587 524 587 574 550 436 550 436 606 574 931 733 584 485 614 537 645 559 601 516 913 725 739 561 1024 763 1079 901 885 692 676 495 570 402 626 490 626 490 674 515 889 640 638 550 611 541 611 552 908 692 908 692 239 598 514 729 561 712 552 729 561 611 541 844 680 225 658 527 575 658 527 575 947 889 936 569 563 747 563 747 563 909 708 584 485 584 431 708 552 708 552 765 572 765 572 765 572 676 516 626 490 626 490 626 490 611 541 550 436 788 712 652 486 584 485 712 552 883 734 739 561 658 561 739 561 611 554 611 541 626 490 676 516 658 527 575 569 563 569 563 569 563 584 485 765 572 765 572 765 572 765 572 788 712 676 516 676 516 676 516 608 547 608 547 992 767 992 767 708 552 788 712 584 485 569 563 708 551 765 572 909 708 550 436 652 486 626 490 658 527 575 569 563 708 552 765 572 626 490 788 712 676 516 992 767 608 547 569 563 992 767 765 572 747 563 765 572 587 574 584 485 739 561 550 436 676 495 747 563]1180 1185 0 1186[641 556 590 496 783 731 592 1083 878]1195 1198 248 1199 1202 243 1203 1206 260 1207 1209 340 1210[468 449 230 690]1214 1222 230 1223[462 394 462]1226 1227 396 1228[471 394 462]1231 1232 396 1233[343 199]1235 1236 390 1237 1240 230 1241[390 230]1243 1246 439 1247 1250 295 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 230 1262 1263 358 1264[593 504]1266 1267 495 1268[582 518 425 626 547 695 610 431 367 598 680 582 561 518 729 640 1067 1183 883 820 579 520 516 587 571 570 598 494]1296 1297 778 1298[454 476 475 1113 842]1303 1304 296 1305[432 564 503]1308 1309 211 1310 1312 499 1313[511 230]1315 1321 499 1322[504 499 348 725 656 572 575 707 375 290 203 358]1334 1335 378 1336[409 410]1338 1340 398 1341[161 178 571 398]1345 1346 405 1347[240 330 206 388 235]1352 1356 388 1357[362]1358 1359 388 1360 1361 161 1362[307 139 370 183 142 388 235]1369 1373 388 1374[362]1375 1376 388 1377 1378 161 1379[307 139 370 183 142 388 235]1386 1390 388 1391[362]1392 1393 388 1394 1395 138 1396[388 235]1398 1402 388 1403[362]1404 1405 388 1406[796 746 864 796 914 796]1412 1413 914 1414[838]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj278 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj279 0 obj<</Ascent 1079/CIDSet 280 0 R/CapHeight 667/Descent -325/Flags 4/FontBBox[-356 -325 1136 1079]/FontFamily(Proxima Nova)/FontFile3 281 0 R/FontName/FFVYED+ProximaNova-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 76/Type/FontDescriptor/XHeight 483>>endobj280 0 obj<</Filter/FlateDecode/Length 17>>stream
+H‰j`€&€  < «
+endstreamendobj281 0 obj<</Filter/FlateDecode/Length 540/Subtype/CIDFontType0C>>stream
+H‰bd`ab`dd”vs‹tuÑ(Ê¯ÈÌMôË/KÔJM/ÍI,Iëýþ!ÓÍ#÷C–ñ‡Ë9Ñß?~ß”a)øušõ;#Ò÷(þïi‚ßyTÔò¨0°22²ñ¹‡¤;¦ä'¥z¦¤æ•d–T:çTe¦g”(Äh$Çh*ø&e+gææçççé(˜ê)8æä(€+¥§•¥¦èé»‡T¤*˜(¤¤¦as Ä1d1ä0€ÈCjÙ'¹ô®ü¹h%ãÍUß·¬fþáh(úóÞïÏï±¿¼Rô÷–Ÿ‹¾oaãûÑ\îç9Æ]7™w}oý­òæ7Ów•Çû×ïÞ ¹“5!;©<RZÅûö·o§o}Ú»¥"~µüÞ¬»ÓÂ×KÿVÑúÍô[Yžïçže?ÎÕ—]»ö=çÚ÷ÜkÂw~Š}ÿÈþ&f±«Wl|ÜÞÚÄÍŽÒ.^9åòÂ{.:ü)¿Æ.|çûWöMK÷¯ß#}jiŠŸüï;×¾cß¸äÀú½Ò'—Øù~\€¹ðûÕ[Ìß7Õ‹~Wþí»Âwýï¬¿Õ«ëÿfý­ð[áùo¶ïêòçXT¿{{ôñ§OGŒ55‚ŒUäù@±ÈùCžGmÇ.¡º?Ê§šþeÚw–Ùl¿ËfÏœÎ.·ÀÌtæÌÿ<œÝ<Ü«¹np¯^Ö?‡çÆ$^€  ¶íîÑ
+endstreamendobj282 0 obj<</Filter/FlateDecode/Length 4096>>stream
+H‰lWI®ÉÜ¿SÔª”ó°µxe†>À‡Ý½xj Û÷Á «¾Z‚ ýÇ²˜d0"òË?¾_þþ5ùë×ã•®<Ç‘®Þç‘?~y}ùÛ¿ÒñËÿ^½¬+×rìãìyÛÏ¾ûUÖñÇ^ÿ}ýþJÇÈ•ñêûZxÌCÜþ÷ñÛ+YþŽŸ	ÿ¦qµŒGk±®ããÛ‹·¾½æ•VÇ¯÷_Íå8‘WªÇ¾Rzf0:îä« —WNW›õ8Ë•zÃÚ×^ó8ëÕv¾£~Í®G-\WJûˆ÷U[Ãª³w¬š®4*žåV·Åsåc]5ãÅŒîvÌ«îzGÈ=~¿_¿2*íJeb?þžÇof0æ¾/ R©e„Õv–û•7/W[ƒ	Ï« ©’¯6Ž¼®½Q-ã*kÇ¢àrÅ’/<µ¹Ÿ<®QÛ5KâývõÅh—†KæŒf¶Á2pŸîçµñRDýêÍö˜ÅÝxÕö€•W)GFR–E=ê•W=ÎÄÂ€JL¶ õ·ž­k ëš¸ˆ|WµväÑ¤;ñÔ3o{´`7þ¯ÅúÉd­ÚåêÁÇëD5÷hqá}_8[bßìLüüØýçgL6Tmg”m¶+·YLže@¿‰Ê³£Ú‰¿ÏúE³ßéLæa‘ý÷Ž€½àéíÑ¯ÆÖøÂGþóý*×Ä6Û¨/â—ýx)Ð—ß)'-ìrš {ß‡ÿùv_8ÕÙ÷sa^k ·±PêzÄ‰Tz¯ŸÄ~”ûÂ›šó¹€Fîq¯‘>‡·ûGßwìà/5ûUù®¾ä¬\ü‹¬dýÂ½Y-ö§½Xç3qE”. "uPæ¿ž»S[€£ÍŒ·yÔ´cÎÏ¼N¢AB™µ6†:‘J®WR"ŽO^Å8©äíÇ[íZx£.ô€\8©uc*üYW«FT˜s ¨Z8ÉiyÌ)ß˜¥	n\ˆÀ£\¾¦l"k†™dB÷$A5sFZZ–¥bÌë1¡´ýû1>ÉT¾QvÿÙŽ~³Ù Š]ï):«…Dv­œÏX(Ôk¶îénL9ª9'·ößÔ¦l¤a(Œ><(0©½LîË‹à·€O™Ò¾ãò {®ÍB´mü=Q#ð$4l®.Á” ôpªg÷ç1 ÅR5ZW'Oÿ€G|Ãà1èsCÚ@G`ùöcÌ%÷2‰yf%j¤™þžÀjêlrÙû‚d÷O…2±^VK€>ƒ?1Mí ä‘UÑVM–nrÏÌYÐ·uÜÕ ê±Œ ~LæG‚RPèÙD/MúózÀ2C¬!Aý©Ý™©a"jUwÆÅÄ™†TlN@88†çŒh¬åM¯˜7ŽL¶»mƒX'Aa4Oˆ;jFé˜=ÖÍh!¤fÓ±·CdR…Pu[®¢¼R—VfŒ‰ÁÈžÖðyìF4ˆ^u›
+oRNP$².r a .c“·‘O¥ð¼Ô_ˆ@˜ÈÜÁLÕ%'…‰­j›²VÌ¶mÙ€K6ÀÄ$c~áÖ®ÑÅ¡gy!:‡pšïQ«Ì€4ïNÅàS¬‡:ÂçlÞ–MåNf`XNòHRšÍ¨6ã»ZåêœÆ ¾ÅÈy:í2è¶†‘Æ,=‘¦PÏy–›À EtFZkÎôüPwã÷#HßU5|âqß¦œ[o“Q_µ:RûcOhÞ’E¬­„•L’¼MáI&o!gàµÙNý‰„1©d/md'áÄ‘²~Áiˆ=·`àíS~rêT±X0£4ÊÕ¼ÝÎõŽn’R2H´´›¡5ÿX/ØhR]h³%ITz3æê*ÞZ!nÛdÛ…ó*UÝ[|;äHõó»ÀNY2bÙ	åÜ&¬Ñ‚ìJ”·rØ,S(‹ÓRpC ýé­ÈIÉReCXîn*´¬<žû^zwÄH›f¤Um›{RhÙŠo[•ê°³ÉÇËÃÆ“‹kµäH>êf½O1:©aJŒÖOE¢%æ‡q¯dÐñY%P)Ò€˜(ZVL!ÅÀPÅ¨Þçj'£Ó§õÊ:/‘ÃüÔ/há·UXVéû¸b“Ý³ãæ‡¦×UÌMó0EkŠ&BN1þéL Ù²A±";VÅ¥>
+ÙÁÕÒ2ã\Ã’†§cH¬éû²²>A`—HÈÆ9ÐøghLátB]7·¯Á+nyžñÞ¤™”mµs/ÂƒÒéé»U±>£n&5|Dœ_8M†ÌÍþ	S‘¤ÛÅ>in5†Â	Ä…ûá×† Óm ¥!XÆƒš–P‘®Y>QoÚ!ß&4¦®Þa=O¡¹½ºvSk®ÒÖÃ|4…š›_kSè#«·Ò!Ùf{H2sß<t.zGZ¾M¾m¬xªF5Æêêw˜bNÍQÐWút^ðHž~l»mdoÞa–Ýæ„e”›h“ÿX‘†‚8yH	÷²e$…ÌŽ:¨¤|©¾yYKåNl1ÿ¾A&þ:×§=—ìäRê¶d¨xä61šgŸ[}y¤ú¨5¦†ït–ÅFAðQ	•á{:ð÷ÐˆîçÅ!IcâSá 
+‡­ßŒ’LêšÁ#¡¾ÙÔ2ÄRG—
+p†Q	›(#Z Y¶÷#:Sô'.8“ø»çsô²¿*‡ÌJc±ÂËø¹ÈO‰hiÝ*–e¦%OQoßëE‹ ì{øH¯šm.ÒÊÏÌAßò.ôT‡îÆµ—T}%I¹Œµúc d”ÜÍ8áÆ‰€S^yNžÖÖÀ''ÇÎØ+¥´žÂi§¯8‰Œu;ZŽ‰àãå,év_g©'’Vk†?^ÔˆxóíQZ‡f=ôŽˆð¾ã…¶fÖC»ÑõE„’¾ò]Â€v{Ÿ
+¬žfm¼Îw®üâ;÷…÷¹íô³š£Å1æÒ¨ÈZjÖÉï¢åKÌCQ¯ŠPóªá.N#»!kîqú'[¬óÛCë¹spr’¡&5>Š1¡ÿ6,“±¢A– BzDÂµpÏØÏ
+þæíÓœƒy$‹£"ó0f,‡¤*“çqè{0ê>%Ü£ÊÀìMS6U“I7 Jb™½¼Î ^|n«waçágÍ»S3ávx"½ \¥¨qÁýxIÂÜ(S”Jµôz˜Kç9CèÊnâëhérÍô§ ò²n•ÏÂˆNÇÖc×¼9ì´##ç=ór$à_Z„ŠŸ.ƒù°#ªJTnßH”Qb!eˆ9u+.ƒß(aRŸÝéá{*|)¶¨3‡.ßyØ˜}Æn˜©àBUÄ£[9ã®0›5(Œ#Yµ:øÏïFÖêbÎcÊIÏ`:Oiò<	Q%™’vˆçZÔbD¹MbF!Ú¨ÿÿë_96¬cÅ`äsS2˜	šmq‰PòÄ3ërò‰ÄuC˜ $Ù1é| K¸Ê-ånÜ”†k‘GžMbU UdM5mlà>-ì(
+eAH‰Pê<ø¥ì{rë%ÓŽ€&UBòËÓvúQgWJd—ÍJeÜ’hÊG;[°DãpAe×9ànŸTP¬UŒ­¤úxÈ&M`ã”›Áãvò«Z×i$Åç\æ±CKç;%ôû"hMsê‡7·T÷±3d–]‡ßU[ÇX|öTGw§~TDÛ’ÑœïÀ4˜.>ç!º«"Ý÷E'§[Ü8h`­•˜‡’ÆÜ• Žÿ'½\zë¸a(¼Ÿ_q—íbZ½5b×í*@ÓuØnëâ&œèÏ/¥ÑØ±“ cLAWŠ<ü¨*ÍÒ£³U•ë©µ'ÖpŠB9
+XB.L"&Ö	%	48$JÕPª*xí(°3(U²Pñ1ôv´qš©”‰8uSS˜go¬ohŠå‰µuªjUfÐñÊ§š)^2ÒnwVf·‚Íy²Eð4ƒ_„©›×S#iÚà.î´ÊI¨g»Hé8ØR _êh6\-–¸[g5Û®unÀÎ°3r	Uª
+l¨¦q-¼µèÍÌ,Y²riŸ»MÛmnÖm®"†K-ä‰Ô± ¢ÙUCRkM–vZPKÈƒP<TÓ€ËFqZDHË‹”Õ©šé&â3R&ôF ã˜e4»‹Fe½4`û™<«Eµ»5RfÍW¹Õ±ª>kkhlàÜ,½eÀ€»ÛE¼›mrƒ QÒÅò¬¬|yÝCÃÐžØRfÃ©öÌ7]DŠŠÕ&=8ÿeADÀÂó`¼Gýac5qÁÖ 2ž­?hf+zÛéIãª4‘¤r™ ‘´zM>Ë*”6pî³LÍiðâ'FÈ¢êGe‘nÛ£«†ÃÐq«Ñ¡Ñ¸‹õT)Uw²„"ì]O.ŒIý¤±ƒ«šæÓbøÚ‚›ƒü¿yž¥“%SjµÖÜ±ß0Òe+b8¾Ì£IrKä`—(âž"–NE~¶b­ é£ázj=%4®ŠlÊ×ÝœB×.Œ¶B¥þ‘%Ó²Æ={¿Ç{f¬?Ç½rQÌçÈ#å=U½4Ü@ÜíÖøŠC©5/Ì K©É?OöØÌàÎè‹ÐòÀµÙAÊÊ(W”Ë_‹rG’[Ÿ ¹x$¹òÉùgH.=Crñó$w¨o¾²Ôc	È_P¾…—‘óž4ÖÜu1Å•)—3``@$eg@d€ë©00 ÚO0 °h¬wÔfeg@-`Fƒ2 ž£3 6D#®ËÀ€pFg<ºêÀ€ZgvyDÀå€!§ a .*¬ W# ®Ë €¾< @ëˆ€ŠÓ®õÊ»S`Ìe¤@²h§@Õº‘3J÷S¸–4R ˆ³x£À ú×)P6@`XFŒÞÓn‚)xs0T?8ˆÌÑ	PëNG@-I.º)míŽ€ZövTGjŒ5T0’ ±ón¡°••ihŠÉC 	"¤D„/¯p“?Ýßê¬‹M…Ôîÿš~Üü+Èíö§4:(Ÿ¼Hvâ)c€“DF·7Ów÷¯ßÞ|¿ýƒt®J:`”¶ˆç"‰‹¤¾ˆdÑr‘Å"¿}¼»¹=ß½½}•®6ùí¿¯ÿþãÝ«íö¿W7wN/?žðÒá„«cMl•ò#‘´ÝL?	M:çÊ¯ò'ßêøÍËWòM.]\Úÿò-/dBüÑÇL"‚Û/_¾~‰Cy;”ü°ä6ØNÚÊX‰Ò	ƒ”`º®ñÌåáLß.lÉZTŽŠÔ.Ii»{Áæ<mvÚ÷s.­bÛmŠŒWoså[çø@ßô¯;øÆü’^pu¬Rœý2q¶~‹Ýçêååiú_€ âIF¥
+endstreamendobj283 0 obj[285 0 R]endobj284 0 obj<</Filter/FlateDecode/Length 230>>stream
+H‰\MjÃ0…÷:Å,“EPh!`Å¡àEˆÓÈÒØÄ#1–¾}ÇŠI¡’½÷‰§ÑU}®É'Ðßlƒ	:OŽq[„{OêpçmZ»¼ÛÁD¥næ1áPSTQ€¾ˆ8&žaóæB‹[¥¿Ø!{êaóS5[ÐÍã¤{(KpØÉC&~šAglW;Ñ}šwÂü9®sD8æþðcƒÃ1‹l¨GUì¥J(Þ¥J…äþé+Õvöfxq¿¾ˆ[ŽSv¯÷'ßƒg(;1Kž<ƒd‰à	ŸcŠ!‚PËR¿ ¦no¦
+endstreamendobj285 0 obj<</BaseFont/XWWPFT+ProximaNova-Bold/CIDSystemInfo 286 0 R/DW 1000/FontDescriptor 287 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj286 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj287 0 obj<</Ascent 1079/CIDSet 288 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 289 0 R/FontName/XWWPFT+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj288 0 obj<</Filter/FlateDecode/Length 15>>stream
+H‰j`@ €  ‘ …
+endstreamendobj289 0 obj<</Filter/FlateDecode/Length 352/Subtype/CIDFontType0C>>stream
+H‰bd`ab`dd”ˆpÑ(Ê¯ÈÌMôË/KÔuÊÏIÉéþþ!ÓÍ#÷C–ñ‡Ë9Ñ?¢XdXÖü:Íú‘Gé{0ÿ÷HÁïa<ªßwó¨0°22²ñ¹‡¤8¦ä'¥z¦¤æ•d–T:çTe¦g”(Äh$Çh*ø&e+gææçççé(˜ê)8æä(€+¥§•¥¦èé»‡T¤*˜(¤¤¦a8RA#£ZìrÃ•?­d<»êû–ÕÌ?LEÞûýùï=öï—WŠþÞòsÑ÷-l|ß'.(ûQ^þ¬\hïwßòß……?|ú±OtëÚµ[·f®MLÊÈLL\—¹E^øÅé?ûD”ÿþSÎÎ
+Îò<j»¾Ÿª›ñ£|ú¡é_¦}g™Íö»löÌéìrÌLgÎüÏÃÙÍÃ½ë»÷†Cæðð|›ÉÃ` ¹Í˜
+endstreamendobjxref
+0 1
+0000000000 65535 f
+2 1
+0001200673 00000 n
+5 3
+0001245732 00000 n
+0001246206 00000 n
+0001246679 00000 n
+95 1
+0001247147 00000 n
+271 19
+0001247366 00000 n
+0001247507 00000 n
+0001247651 00000 n
+0001255796 00000 n
+0001260189 00000 n
+0001260216 00000 n
+0001260527 00000 n
+0001265609 00000 n
+0001265679 00000 n
+0001265961 00000 n
+0001266048 00000 n
+0001266681 00000 n
+0001270849 00000 n
+0001270876 00000 n
+0001271177 00000 n
+0001276302 00000 n
+0001276372 00000 n
+0001276652 00000 n
+0001276737 00000 n
+trailer
+<</Size 290/Root 1 0 R/Info 95 0 R/ID[<15C714B85E4E4D4F8AB0F10B2A2B6432><219D6A4CE15EB34980C4CD156136AB2B>]/Prev 1196704>>
+startxref
+1277182
+%%EOF

--- a/Presearch - Brand Guidelines - 1.1.0.pdf
+++ b/Presearch - Brand Guidelines - 1.1.0.pdf
@@ -6685,3 +6685,874 @@ trailer
 startxref
 1277182
 %%EOF
+2 0 obj<</Length 44981/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 9.1-c001 79.675d0f7, 2023/06/11-19:21:16        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:illustrator="http://ns.adobe.com/illustrator/1.0/"
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Presearch - Brand Guidelines - 1.0.0</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <xmp:MetadataDate>2024-06-26T15:57:31-07:00</xmp:MetadataDate>
+         <xmp:ModifyDate>2024-06-26T15:57:31-07:00</xmp:ModifyDate>
+         <xmp:CreateDate>2019-01-29T13:30:10-05:00</xmp:CreateDate>
+         <xmp:CreatorTool>Adobe Illustrator CC 23.0 (Macintosh)</xmp:CreatorTool>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>20</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAFAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8ADPbXKQpO8TrDJtHKVIVv&#xA;k3Q9M9WE4k1e7wBiavoj/K3/ACk+kf8AMbbf8nVyjW/3E/6kvubtN/ex/rD7305a31leK7WlxFcL&#xA;G5jkaJ1cK605KeJNGFRUZ5g9yxjW7yG31thNDdujKrGSGScIONaUjjotSeu+Z2PKBjra/wCqD9ri&#xA;Thc76e8/cn1mUkuIyHO0fML6rA7kj4ofp65hz5uTHkk9n5kiu/NdxYW8kUtxChjnt1u3PCKOZkMv&#xA;oelQPyqp+LtSuZmTHGGMCRqRHEPT3jvvk48JylMkcuX1d3lXNrzjqtjZXdkl2ZQjBjWKaSI06Goj&#xA;py+k5DT5BGJ7/wCqD9/JlmgZEfrITLSNV0w6Kt/64isQaCe4fiBRvT+J5D3bbc5XKMskqiLJ7h+g&#xA;MwRCO5oebzz87kbUD5dFgDdmcXZhEA9TmKQmq8K8tt9s6X2bPh+Lx+muG72/nOk7a9fBw73xcvgk&#xA;f5dM2mW2vC+jlgdBaiSPlJbyglnI+JRzWv4jMjtzLH93IEEerukOjT2Xjl6xW+3k9L8u63De2t0N&#xA;JUyXlvGrtFcyyMlXJAHqvyanwHOXnKMpeo+nyAH2O9jGUY7DfzP6Uu/Mm5u7ryLqPrLbJDzt1EsE&#xA;7Tjl66V5D0kpQb7V+WZ/YwgNVHhJP1dAP4T/AEi4naRkcEuIAcut9fc898r2ukW3nnRP0XM06mNz&#xA;OrrIrCYQvypzRPhb9n8c6LWzyS0uTxBW+3LlY8zu6fSxgM8OE3+ui9Q0CZjccGtrqJgAA808s6kV&#xA;qa+oaA9Ogzk8+QS5V/pRH7noMMCOf+6JS3T/ADX5t1jzXdaVpl/pCWtq8hlDWt3NMkUciIAxM1uh&#xA;Y/Eu3dgdwpDa5zGSWWt3M2qCzeS2ZeTqRH6gf4AT0YU7eOKsf1PzFpVr5iuo7r10MUgqy3E3CqqC&#xA;KQqQlD3zPjlAxgbX/VH383EOMmd/74/cy68NwNLP1f1/WovH6sITL9oV4/WP3fTrXt75hS5uVHkh&#xA;vLthqdvarNf6lf3klxFGxttRWwWSBiWdlP1GGJC45hG+Jl+Ece7NFKV+dNWtLG6tPX9QlkcqI55Y&#xA;AdwDyEf2qe/TMzTZBEG/9yD97jZ4EkV95H3JF528xLbeS7PU7G7ltY3uUhWX1pIyRwkBDOGDNvH3&#xA;OX6XDDLlIndUTtt1atRkljhced9UD5i84/mBCnLSpIH+r3hiuFEUbsYAe4eSMhtt+IPyyvW6eGMQ&#xA;4b3G7PS5pTMuLoWWXGrzv5Liv9TSSGZ2AmVWe3cESkChQclrxH0Zj6eQjKz91/YW7NEmND76VvKO&#xA;pW18jmBJV4Greq8koPIbcXk3PTpk9RIS5fdX3MMMSOf32wbzSnPzAWs7CID6yfrD2mpW1GkVuMbT&#xA;RyR8kkBrxj7mvdcxXIZ/5V9BfLEIt4oY1SMr6UFyLxQyqBx9cKvIilOmGPMIlyQfl/kXJaC5i4/C&#xA;rTzyzctwekh2P0Zn58glyr/Sgfc4mKBHP7yURL598uxyyRNMS0TtG9ChHJGKsPtdiM17mKll510O&#xA;9u4rW3kLTTNxQVTr/wAFiqQax5j0+z165jlEpeOVS1LmZUFAOkS/B8x0ObGGSPABfT+aPvcOUJcR&#xA;Nf7I/cnmpa1f6TOLm7lsINC9IKJrqf6s/wBYJJp6jkpx4KdqV+7MCQ3coGgo6f560vUbkWun3ul3&#xA;ly26wW+pQyyHtsqKTkaSSHhkfmvzPbaXbWUU7wWUW0JVAvIci1C1PiFT0OelnQ4JZDIi5F4karKI&#xA;iINRRGh+YdZvvMWlRXVy0kbXttyWigGkykdAO+V6nSY4YZmIo8EvuZ4M85ZIgn+Ife99ttI8rXE0&#xA;l1bWVjLMs/OWeOKFmFwh5cmZRX1AWrXrvnAfm8tcPHKqrmeXd7nrvy+O74Y3z5DmuuJofrbRc19X&#xA;r6dRyp4064YRPDfREpC6ck0ZuFt2kdTLGwHExrx3J5A1EldvllE+bbHkwmHytpi6qtzBqt78Mqr6&#xA;vr2zLWObm7s/LmasKHvTbAUhmWrQaYXhS79N2VaR+sQWPbq25y7FAkbBrySAO5au9H03UNDn027H&#xA;p2MnESBCEoqEMN+gFVyePPLDkE48wxniGSBjLkWAfmpdTaDL5Un0p+cloLr6vI/7wtVYhUn9qobO&#xA;g7DgNQMwnylw3/snUdqSOE4zHnHi/Qg/yy1D9Kahr13qgiDTC1EqkBEBQOqih2H2RlnbeAQx44Q3&#xA;A4vPua+y8plKcpeSfefTHp+gRS6deHSBNcxLJe25daIVc7+j8TD5Zr+ycQllIlHj9J2NeXe5naEy&#xA;MYIlw78/7GKeSL651PzPbWWp6sda0+VJjNp7m4kjbhGzqzRTIqMQwFOprm47RxRxYDLHDw5CvV6Q&#xA;dz3xNut0WSU8ojOXHHfbc9O4vQ/K2k6QIbq5bQ4bC6t5ZPq8zWxjf0iKI6vIisCVrUDpnO6vLkBE&#xA;RklOJAv1Xv1HN3OnhA2TARI5emtvkm8E0MpDROsig0JUhhX6MxpRI5t8ZA8kJoctrHr2pWyreG5a&#xA;ru86P6HFHJ/dyFVUk+t9w9sjk0xjjE7FHz3+TKGcSmY0bHlt81ul/WpNdk5LcrHG0jEyt+7I3UUH&#xA;AV67b5jNyhfeXfL13qlzLLGst1I3KVeZJFNq8a7ZkiB4QaaDMXVpnrqxN5flWWOGVCEqlxA93Gfj&#xA;HWCOjP8AR069sx8nMuThNEH9NfagvKvlw6bPJdpDpUNtcRAwx6fprWMwLkO/qSGeXmGbenpqa9ch&#xA;EU2ZcvFt6vib/Qi9cs9IuZ4Vvo4ZJKUiEvGu56LXMnFAkE04mSQB5vMf+cgZrbSPy3tPQjMcK6nC&#xA;qxxAD7UM5Ox998tx5eCV+TCcOONM3/w7c3Wn6nDbTBJ5pnMcjqrgEg02cHxyWqzE8NfzWGnxVfvR&#xA;VroQs/Kyadq1wJKSFpJA3pqKuWULTjT+uYuKJJoORkkAN0XoOl2Vi7G0LFJgDVnLigBpSpPjk8go&#xA;MYG3nHnQ6UNb5TX8Lv8AXCClxZyQsjDlVFdLciQGtPUJO3eprlDa9A8l/V18pW4huPrESo1JRbGz&#xA;XauywskbKB7jDHmg8kZBNDKQ0TrIoNCVIYV+jMqUSObRGQPJL08h6cmpTXourkCYszQrIUWrszNu&#xA;tG3JH3ZiOQmEHljT4J45kluecbBlDXEhFQa7gncYqxjVvJtjqWu3Vw97RpHLPAnEutAB7/qzJGM0&#xA;D0aeMXSZ+ZfLl9r6wWV1DZ3OhikrQyiZLgTKGUMkiOAKcv5a5COWUJXE0VnhjkiBIWEHof5TeVdG&#xA;1SDUrK0VbmA1jdpbmTjvUlRJK6g/RhyanJMVKRI80Q02OJsCik5/5UbwFfR4fs/710+jN/8A66ef&#xA;+xdV/gPl/slbTv8AlS36QtfqPo/XfVj+q8frNfV5DhSu32qZDN/KXAeK+Gjf08urPH+S4hw1xXt9&#xA;T0WL0fj9Lj9o8+NPtd6075zjuVGT6j6x58fV/HLBxVtyYHhtVj9D4eHGv7PjTfx3yBu92QWL9Rp8&#xA;HpUqa049a7/jgS1c/UuS/WOPL9nl/DLIcXRhLh6qkfocG4U4fteH45GV9WQroxvzp/gP/Qf8Uen/&#xA;ALs+o8/V/wAj1OPpf7Hrmx7O/NerwPK+XnXP4uFrfA28X4c/0KHlP/lXNbv/AA76VaJ9b4+t0q3C&#xA;vq+9cs135z0+NfWuX6GGl/Lb+HXnz/SjfNH+Df0Uv6f9P9HeovHl6nHnQ8f7vfpXKdF+Z8T9zfHX&#xA;l+lt1Xg8H7z6Uo8rf8qq/TUP+H/S/SnF/R4evWnE8/t/D9muZet/P+GfGvg/zf0OPpfynGPDri+L&#xA;OG48Ty+zTf5ZpA7QoaL9Hf7q40r+zWlfoyyXH1axw9EVlTY7FUM31D1mrx9X9vxy0cdeTD035q6+&#xA;n6YpTh2r0/HKyyC4Upt07YEqFx9T5p6/Hn+xy6/RlkOKtmEuHqhNS/w99T/3K/VfqfMf72cPT50N&#xA;P734eVK5GV9WQromK8N+FOu9PHIpWXHoen+/p6dd+XSuShd7MZVW6yD6pUelStNqV6YZcXVRXRdP&#xA;9U+H6x6ffj6lPppXIMlRuPE8vs03+WEKUNF+jv8AdXGlf2a0r9GWS4+rWOHoisqbHYqhW/R/rNXj&#xA;6v7fj9OW+uvJh6bRKceA4fZ7ZWWQbwJf/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <xmpMM:InstanceID>uuid:47430d26-02e8-4396-a198-75318b5e66f1</xmpMM:InstanceID>
+         <xmpMM:DocumentID>xmp.did:190ddeba-a139-4b41-9eb1-38d2c6e9d89e</xmpMM:DocumentID>
+         <xmpMM:OriginalDocumentID>uuid:5D20892493BFDB11914A8590D31508C8</xmpMM:OriginalDocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>uuid:6a4942c9-3310-7041-adb4-7d5533119c30</stRef:instanceID>
+            <stRef:documentID>xmp.did:0f4b7733-6de2-4a28-957b-2e89a11eee94</stRef:documentID>
+            <stRef:originalDocumentID>uuid:5D20892493BFDB11914A8590D31508C8</stRef:originalDocumentID>
+            <stRef:renditionClass>proof:pdf</stRef:renditionClass>
+         </xmpMM:DerivedFrom>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:d00941e1-6ad2-4e14-878c-be0b9de829c7</stEvt:instanceID>
+                  <stEvt:when>2018-11-06T11:14:15-05:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:190ddeba-a139-4b41-9eb1-38d2c6e9d89e</stEvt:instanceID>
+                  <stEvt:when>2019-01-29T13:29:51-05:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <illustrator:StartupProfile>Print</illustrator:StartupProfile>
+         <xmpTPg:HasVisibleOverprint>True</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:HasVisibleTransparency>True</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>841.890000</stDim:w>
+            <stDim:h>595.280000</stDim:h>
+            <stDim:unit>Points</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:Fonts>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>MyriadPro-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Myriad Pro</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 2.106;PS 2.000;hotconv 1.0.70;makeotf.lib2.5.58329</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>MyriadPro-Regular.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Light</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Light</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.5474.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.175.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Medium</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Medium</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.25136.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Semibold</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Semibold</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.173.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ProximaNova-Bold</stFnt:fontName>
+                  <stFnt:fontFamily>Proxima Nova</stFnt:fontFamily>
+                  <stFnt:fontFace>Bold</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 3.014;PS 003.014;hotconv 1.0.88;makeotf.lib2.5.64775</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>.139.otf</stFnt:fontFileName>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpTPg:Fonts>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Magenta</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+               <rdf:li>Black</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Default Swatch Group</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>White</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>Black</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>35</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>32</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Red</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Yellow</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Green</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>166</xmpG:green>
+                           <xmpG:blue>81</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Cyan</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>174</xmpG:green>
+                           <xmpG:blue>239</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Blue</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>46</xmpG:red>
+                           <xmpG:green>49</xmpG:green>
+                           <xmpG:blue>146</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>CMYK Magenta</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>236</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>140</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=15 M=100 Y=90 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>190</xmpG:red>
+                           <xmpG:green>30</xmpG:green>
+                           <xmpG:blue>45</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=90 Y=85 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>239</xmpG:red>
+                           <xmpG:green>65</xmpG:green>
+                           <xmpG:blue>54</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=80 Y=95 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>90</xmpG:green>
+                           <xmpG:blue>41</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=50 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>247</xmpG:red>
+                           <xmpG:green>148</xmpG:green>
+                           <xmpG:blue>29</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=35 Y=85 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>251</xmpG:red>
+                           <xmpG:green>176</xmpG:green>
+                           <xmpG:blue>64</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=5 M=0 Y=90 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>249</xmpG:red>
+                           <xmpG:green>237</xmpG:green>
+                           <xmpG:blue>50</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=20 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>215</xmpG:red>
+                           <xmpG:green>223</xmpG:green>
+                           <xmpG:blue>35</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>141</xmpG:red>
+                           <xmpG:green>198</xmpG:green>
+                           <xmpG:blue>63</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=0 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>57</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>74</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=10 Y=100 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>148</xmpG:green>
+                           <xmpG:blue>68</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=90 M=30 Y=95 K=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>104</xmpG:green>
+                           <xmpG:blue>56</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=0 Y=75 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>43</xmpG:red>
+                           <xmpG:green>182</xmpG:green>
+                           <xmpG:blue>115</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=80 M=10 Y=45 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>167</xmpG:green>
+                           <xmpG:blue>157</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=70 M=15 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>39</xmpG:red>
+                           <xmpG:green>170</xmpG:green>
+                           <xmpG:blue>225</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=50 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>27</xmpG:red>
+                           <xmpG:green>117</xmpG:green>
+                           <xmpG:blue>188</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=95 Y=5 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>43</xmpG:red>
+                           <xmpG:green>57</xmpG:green>
+                           <xmpG:blue>144</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=100 Y=25 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>38</xmpG:red>
+                           <xmpG:green>34</xmpG:green>
+                           <xmpG:blue>98</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=75 M=100 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>102</xmpG:red>
+                           <xmpG:green>45</xmpG:green>
+                           <xmpG:blue>145</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=100 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>146</xmpG:red>
+                           <xmpG:green>39</xmpG:green>
+                           <xmpG:blue>143</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=35 M=100 Y=35 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>158</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>99</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=10 M=100 Y=50 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>218</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>92</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=95 Y=20 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>238</xmpG:red>
+                           <xmpG:green>42</xmpG:green>
+                           <xmpG:blue>123</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=25 M=25 Y=40 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>194</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>155</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=45 Y=50 K=5</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>155</xmpG:red>
+                           <xmpG:green>133</xmpG:green>
+                           <xmpG:blue>121</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=50 Y=60 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>114</xmpG:red>
+                           <xmpG:green>102</xmpG:green>
+                           <xmpG:blue>88</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=55 M=60 Y=65 K=40</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>89</xmpG:red>
+                           <xmpG:green>74</xmpG:green>
+                           <xmpG:blue>66</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=25 M=40 Y=65 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>196</xmpG:red>
+                           <xmpG:green>154</xmpG:green>
+                           <xmpG:blue>108</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=30 M=50 Y=75 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>169</xmpG:red>
+                           <xmpG:green>124</xmpG:green>
+                           <xmpG:blue>80</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=35 M=60 Y=80 K=25</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>139</xmpG:red>
+                           <xmpG:green>94</xmpG:green>
+                           <xmpG:blue>60</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=65 Y=90 K=35</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>117</xmpG:red>
+                           <xmpG:green>76</xmpG:green>
+                           <xmpG:blue>41</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=40 M=70 Y=100 K=50</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>96</xmpG:red>
+                           <xmpG:green>57</xmpG:green>
+                           <xmpG:blue>19</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=50 M=70 Y=80 K=70</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>60</xmpG:red>
+                           <xmpG:green>36</xmpG:green>
+                           <xmpG:blue>21</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>2d8eff</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>45</xmpG:red>
+                           <xmpG:green>142</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=14 G=50 B=79</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>14</xmpG:red>
+                           <xmpG:green>50</xmpG:green>
+                           <xmpG:blue>79</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=243 G=248 B=255</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>243</xmpG:red>
+                           <xmpG:green>248</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=73 G=73 B=73</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>73</xmpG:red>
+                           <xmpG:green>73</xmpG:green>
+                           <xmpG:blue>73</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=250 G=251 B=252</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>250</xmpG:red>
+                           <xmpG:green>251</xmpG:green>
+                           <xmpG:blue>252</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=217 G=234 B=242</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>217</xmpG:red>
+                           <xmpG:green>234</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Grays</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=100</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>35</xmpG:red>
+                           <xmpG:green>31</xmpG:green>
+                           <xmpG:blue>32</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=90</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>65</xmpG:red>
+                           <xmpG:green>64</xmpG:green>
+                           <xmpG:blue>66</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=80</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>88</xmpG:red>
+                           <xmpG:green>89</xmpG:green>
+                           <xmpG:blue>91</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=70</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>109</xmpG:red>
+                           <xmpG:green>110</xmpG:green>
+                           <xmpG:blue>113</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=60</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>128</xmpG:red>
+                           <xmpG:green>130</xmpG:green>
+                           <xmpG:blue>133</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=50</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>147</xmpG:red>
+                           <xmpG:green>149</xmpG:green>
+                           <xmpG:blue>152</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=40</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>167</xmpG:red>
+                           <xmpG:green>169</xmpG:green>
+                           <xmpG:blue>172</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>188</xmpG:red>
+                           <xmpG:green>190</xmpG:green>
+                           <xmpG:blue>192</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=20</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>209</xmpG:red>
+                           <xmpG:green>211</xmpG:green>
+                           <xmpG:blue>212</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=10</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>230</xmpG:red>
+                           <xmpG:green>231</xmpG:green>
+                           <xmpG:blue>232</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=0 Y=0 K=5</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Brights</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=100 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=75 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>242</xmpG:red>
+                           <xmpG:green>101</xmpG:green>
+                           <xmpG:blue>34</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=0 M=10 Y=95 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>222</xmpG:green>
+                           <xmpG:blue>23</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=85 M=10 Y=100 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>161</xmpG:green>
+                           <xmpG:blue>75</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=100 M=90 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>33</xmpG:red>
+                           <xmpG:green>64</xmpG:green>
+                           <xmpG:blue>154</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>C=60 M=90 Y=0 K=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>127</xmpG:red>
+                           <xmpG:green>63</xmpG:green>
+                           <xmpG:blue>152</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+         <pdf:Producer>Adobe PDF library 15.00</pdf:Producer>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+endstreamendobj10 0 obj<</ArtBox[9.0 9.0 781.685 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 331 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 41 0 R/LastModified(D:20240626155651-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 212 0 R/GS1 213 0 R>>/Font<</C0_0 114 0 R/T1_0 108 0 R/T1_1 109 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 196 0 R>>>>/Thumb 43 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj11 0 obj<</ArtBox[9.0 9.0 729.529 604.28]/BleedBox[0.0 0.0 859.89 613.28]/Contents 295 0 R/CropBox[0.0 0.0 859.89 613.28]/Group 45 0 R/LastModified(D:20240626155731-07'00')/MediaBox[0.0 0.0 859.89 613.28]/Parent 3 0 R/PieceInfo<</Illustrator 25 0 R>>/Resources<</ExtGState<</GS0 157 0 R>>/Font<</C0_0 121 0 R/C0_1 290 0 R/C0_2 291 0 R/C0_3 292 0 R/C0_4 293 0 R/C0_5 294 0 R/T1_0 115 0 R/T1_1 116 0 R/T1_2 117 0 R/T1_3 118 0 R/T1_4 119 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 139 0 R>>>>/Thumb 46 0 R/TrimBox[9.0 9.0 850.89 604.28]/Type/Page>>endobj95 0 obj<</CreationDate(D:20190129133010-05'00')/Creator(Adobe Illustrator CC 23.0 \(Macintosh\))/ModDate(D:20240626155731-07'00')/Producer(Adobe PDF library 15.00)/Title(Presearch - Brand Guidelines - 1.0.0)>>endobj290 0 obj<</BaseFont/DFGCEM+ProximaNova-Light/DescendantFonts 324 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 325 0 R/Type/Font>>endobj291 0 obj<</BaseFont/UPVAIE+ProximaNova-Regular/DescendantFonts 317 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 318 0 R/Type/Font>>endobj292 0 obj<</BaseFont/HLJAIE+ProximaNova-Medium/DescendantFonts 310 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 311 0 R/Type/Font>>endobj293 0 obj<</BaseFont/QJSCEM+ProximaNova-Semibold/DescendantFonts 303 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 304 0 R/Type/Font>>endobj294 0 obj<</BaseFont/YVTYMW+ProximaNova-Bold/DescendantFonts 296 0 R/Encoding/Identity-H/Subtype/Type0/ToUnicode 297 0 R/Type/Font>>endobj295 0 obj<</Filter/FlateDecode/Length 5117>>stream
+HâlWKÆπ‹˜)Í]‚'˘€Zº2√‡¡ûY¥òÒ˝Gd$ŸO“@Ä^eãÃ_Dø¸„ÎıÂÔ_”ıóø~ΩÈ^y^¯ø’+_¸Ú¯Ú∑•Îóˇ= ¥k]œ2⁄’VªÀº˛¯œ„øèﬂÈÍπ“ûm›K¬ƒÎ_øa√<:6lmh√ﬂ˘J¯óØûn´u^≠’ªf+◊«∑ﬂ|{îªœäß◊£ﬁi‰ÎôÓT◊Uo+ÖF^£∑F√˙∏>∞pıNsåyŸùÒúÔäÂz.pcbô,ÏZÎü‘ª˘ﬁ}U3gﬂŒ Ó4π.€¢Q∆∏ =˜„ºç«◊„WÎNk¡ˇ¯BÊá&≥m⁄ΩÛsﬁ+!ï˜`ÛnpÎ„—·J°ôÀ∏¬ÑG„Óàb .8‘·2÷MDñil8Ô1±aª~√Ó˜¿ÊèuWfA°0<Ÿ;Fˆen‰ªﬂTeº˙7	õ"«e˙±xÉU8bb-:‰^»<Ï»K««èÅÇ§¨¬Åé≠¯<hÛÿRÕ*å… ÙÓØ'+6{æ‰õû?O∂Ÿ
+ÛµÕgn~ˆã	?œø¢ˇ˘©∑FCz´"≈»˜i≠g…wjÊÕı,∆#V.t2ˇae8Œ∞∑^Ô™j©m
+¢◊ﬁ_[DOØ~GñeiÎ¯>Ì˘Òê©ˇ_a…1Ìê¸›ÍåÒä?ﬂŒ($·˚zˇÄ≠¡€∞YŸM˛Ñ+≥¥œ=Ô?Îªv÷±M§≥ØΩQ:Ê„!3Œzms∞Y¥GAﬁ⁄)˙ØÛ„∫+ˇ‚áüÔÙC¥^Ô4¢[ù 4ÚSnKÁ=ÌÜ»k‚g`®ô7ı'∂!°∞…€ﬁ˜ÏÎÃ∫&@œ`ÙÊ˛äô‚¡WÌ∂5hÃJœ≤dÖ¥ëÃÛ«?’9∆@ß¿hÏ‡¥Ø&⁄ª„sdò¿6GCùD;(†"J2*…!•„·ºçÕQ¥ù[$Ï≈œà^˝hÉÜZbgq9∞ÛìMPŸE¡µ‰ïÜìDÍFVöyyÜ’q∑Ó‘\ƒY•2£âw‡∑¡®Œ”åm—g~#˚¬9≥'`]⁄?¿œ†{ù24	ÜY	¡‹NK¨‘ïä∂˙˚d†¥˘à`∫¢fœ8 ,}Åµa/L®F™πÛ¥üLmxLπ‡ÕâPøg¶LF2d∏Yª´°˛ü—@L¢qãµº-[ﬁE¿ÆKå‰My
+3ïìc[Ÿ(≥©√2‡ŸÚ±–GWCé÷ªπ·K£98	‘ä—pÌ^∆πóä ó;≠Ïï≠Õ€TÜz∂’™umdáÑÒ]Oƒ@ ˘mî>µ∞[#fWŸ;¢¿§+∞	dè“0WFÉœp∏h`„6ÀP3K2£ö¯hDΩßØ∞Çtö£zK˚ÜFÒûf€Çö}Ê1«%ˆ`•YoT@ÏÍ^{n'˜’jÄáBc}çIﬁ  ¢~èUTÛAI3J#œ]*Ç¶4P‡¨◊Å`Àh;$+m$.R4πg xLî9cõ+∏`á2“çºŸ 1$_(”ânze›r&™Œï}ÔH—ÎE»§5yò'Ìä0  çÌ_¢Êù=û™ìcÍÆˆ≤tYY-∏⁄ã>íS7—√†w"ÔßHô∫∞ö*CR}“!X4F®=	Ü¨Zöz§Úò,µ•o:<üå“4|Cêß5…PG&ıŒ€
+rë3t¥Bnπ˚pÅôR4íÔ†6ÒÒ+ 0u€ºó®"√~>‚K¥)It`Å:ír†'zñ_‡}ÈD.\¯"+„CB
+s1qA˚"èÄrtÓ.`áœ∫)∆øv≈‹Pî©ÏwëY¢_ìè9U«¢Áë8%«Û$TÛ)Q<›£πÇ* ÏX”'Âzì3G8èhÊ∫O‰Xä‹dö˝œâ{@„JH/jﬂ+àôÇ:LEtÀõ∫∞©ü‚jèu©ç¨:];Ê∞°Æ"´¨]fol∑µ≠+‡9Ïg∫ße^4º%⁄ü¸†˘È∂MıWıÉ¶zè\¸X√Ø∑ˇeEwüCcJ„–%M$Jä&åLµ-∂dVîÍπ„†wõ°ò5ÕÔÚöƒœûIŒY![«ô¶d@|˙fŸt4ÕçvØAìö≠j∆¢:Y[zÆ·UU…1ièQΩ^’÷a•◊‚`ÈVU¸müÎPBÛdΩ	ÉÑ^ùêÿáÆ`íVÌ›¶÷<¢ÇîŸ,ÿÔ'sÌ+e:¡h≈áÍ(ºxå^÷B”´∂Ê˝T¸ ÀJ)K{4ìÃ@¶ì.)$ñ3˙FJÍ[òdJ%YGu+iS¬EÚGUıXZ%62å9Ω9ìøôÆ˙Ÿ…âwﬁ©<q*ÖNHœæ4e®AëıóG∫€—eS$dıXª¸2ºÎ{ﬁé≈ºQïc)ˆ<s¶çˆs≠Â¨ ~óìE¢w'4°HYﬁõ©–p@ÍT∞A?¥œ{BGﬂÈÍ@ S-€ÚŒ/‰e‘†ÚXì qjú´GBçøòÄŸ¶í÷˝"„3r:I‰~†»¥æ∂*®WPıD_“0;F®(_∂ìÇæ{ûÎÑﬂBBà«”íÜ»G≈√≤Vv2‹’4€ôˆï Œô1Ω∆M¢ÁÆãÏ[IHﬂ˘Ã<ñ3.+∞ﬂ"-Vœ†2Òâ£Î`3ëµ«W‹;fÓp•¥5ÅÍe§4&=∆Xòû¥8üQƒ|”ÊsıtÓ7´o˘(á¡Ö+y#OáßO˙m8…hÃ<BéÎª◊6˜Ö/ËPÊ5ÈÍ;Ñˇ4'2≤6ÆHuÀ'˛.∫ñ|ÙŸÊmèUm·∞s?ã«∏f∏e”œπ˝∞â“ëUª•î÷∞º†Æi‚-Í⁄õ†Á≈∑q‰ô8q…GêUQ iàrƒ£9w†√∆‰ i∆ ÍO/ìÌ˝¢π“©	˙73Õ≥åm¥ qÆØ(ü÷>Ä˜õÆx8πMÍYWÑ˛jP8ätwD	8ÕµS0¿-+Ú#&ç‘Ålß’üè^”^'Û%Ωòê*tàpËìâ7I %A@˛≤+≠ÈÎ°ˆÉG≥^R ∫ÅHü-¥Iå{i!µbOêËB∑8—Ç2jäàËëºøPûπEÎÇ+¡êº»aˇ™ªråjT£G´Ò0‘b∞òœ†∫¬jPÔ∫t.~ôÂX0ˆ∫”Œ⁄CP9y¥1˜…éçˆnº≠[w	öe∫6®Â‚U‡+ÚÿÑ#ëõ(∞~¶õŸ+Zºâ˚HA+¬J8 bØπRÁ~t\√}Sù^‡A˛©∏6Óå5É¯YúıõDééÙL0¯%bœ]˜DT¢˘%!®Àå⁄DÛæh 6ˇ≤˛ÃTçn™æÂ¿öƒ!˛&—ãÿ»Ö‡ìª âV5>fW´èk?ffŸﬁ¢»;™ú-Ö'êócf√Æ9◊›J⁄û≥ÀÂ˘\âè¿∂PånHó	›Ÿßßõ‰…D4+JnpÕÔ:Ñ§<CL+Ó$1˝Uˇ3ö%„ñ+¸ß˝˘r„vÙéÙˆSMø¡˚ÑÔ ›H˜•∆˙äã±dádÚrïOﬁ„’ŒÔY`é¢uMö[[ÎAqàñòi	4‡œ≈ÎÌWUÏ‡DØSH¿É§HNvÒ›6{bÅì ^7ˇz°„fÜÍ pBXh€∑YÒÓùå‘¶Á¢¯π"øßﬂÎ!Qˆ‹mË2H¨"fZ˚?ÈÂ÷‹∆qD·w˛ä}r)Qôô›πU•\%…r«í©ŒMIπ bEÆ.îò_ü””≥ª3≥ Ì™<ÿ‚ çπû>˝5Ì◊€HàLî«-ä¢AÌÇÂ)Yá@°Ÿ=I&⁄!#ﬂ´é. ”¡∏u¿V˜Ü’‰˚i“rèC√: %M¢)π¨ØÄ;%⁄á&ÉÒ°y¿≤ñfBÂ
+4i6v3u¿¡òÍP;´ö{V
+◊W.7ZJXëÔáÎq®BwáΩmÒêg¿ﬂä≤5(¶ÒCz£¯Ñä“ÖÏ]U}Ø2ÊÙƒÁ àï<’ü±íå⁄CwGr∑<P√ŸM)d‹¿6L}C…LÚÃŸë©q9÷yﬁ’ó∂†4Ø˚1'Â˙"B@2l˙/£= ±¨ÍÀ1TÈ‚»ÇAB˜â>dΩÒ6∂ä‹“ΩImcπ‡›Úﬂ\ú¬ã≥∏PÆ*ÏgÏÇT:¥lÿ*©!©IÏT[.ô›ï¬z	Í!Çñ5©÷ƒÉP—≠—q∏Óáóêà¨’x_”ò‰¬ïi„ìq|úHzëck1¥oc∏r˜Az;•bsÖk•µhÒ˝eËz„˘¬¡‚—C*“›VÏö¸)ˇ›ﬂ4èÿƒ9:¥âaÓai5ÍDπEa3Jﬂaí’–*‡ÚÜ!¯;wèó—‡áéIqñ≈∆säáB¬µ<j7‹°ØbÉ≠Ú˝ºÎãËœì±ƒIÚ‹ÿ#M?‘:v¡¢„W†/º¿elñÿíX\çKv{Cèf˝«A`oY©6–S»˙Å†UQq˝fx(ØVZ√	Œ#îy°Íˇ°îî°d¬P6a(ó1î>œP&c®˙iÜ"ªvÉõﬂ„‘Œ]ÊÁ*Òsó˘yì¯π˝|ps"4ùZùöN	≠9Oh:!4í^tE>[_∞Oüëó¡ã‘-ô'π∆#x©ëªh∂îª(KÓ“:Â.ëÉ}:êW”å‰˙ãëºËîy—ÈGÚ¬Ω§‰eUB^>E/WßË•Î&AØ∆çËE/ê¢ó1#{5¬$eÎæ`X#|Q¢ız»æ®,'eÖO‡ãs>¬{9√W‰√æ‹_‘ﬂ¶≈x·À4	|˘Ñæ¯◊#}aØ#}yù—óì#}©:Å/]ßeı _Æ÷	|ó¡ÌiÄ/+¯‚í4¿◊ËtQ,=}I·3˙j∏ôÒã3ñGTwÚlÊ⁄ÒÓ‚ÂÇ‘hŸƒP¢™˝Õ≈oÚ'‘/Q->] À∞R€Vã’≈áfÆsãØfªÌÕ~πª}òˇkÒm⁄¶˛ßÇÉ*öJDGáUúÌá”æ∫ﬁﬁÌñõáÍ¯∞k?-Ø€9§
+ú=´Æˆ€y-´ŸóÓnYÒÿæ´ﬂ‡ßo∑˜Àg’ÌÚP}l€Muh◊Ìı±]Uü∂˚™;˛öõ◊ƒzu5;èøπòéÎ∂˙™Z∑7›«n›™Âı~{8Tõ”]ªﬂûª¯9ÑÆ⁄˚Ó∫=<´V›Mw\Æ´Ân∑ÓÆó«nª9`ä>n{:ÓN«™€Tª}∑9>ßœ±O‘Ö∞œÏ¥i,x<T¥ÔÌÒ∂⁄‚ £›∂À’∫€¥8ÀÊX-7´ulÁµ‚´˘r‰Øæ÷™”««6Óó˚éB˙πÌnnèﬁ‘‰ù_	º≥ÔL’0tòﬁo∆Û¸N =Ö0Z+ü¬¯%∆ÉZà∆c¸-∆|neå≈ø÷påÑyº|Eˇ~çXÍ–•‡Ÿ˘Aﬂ\ˆ_ëR¬ Õ˙º/¡öPJ‘Ñ}∏ÿ;
+°—¬F§°Œk –∞óÜVãˇ˙…ÎÙπ=]ﬂ˛∏˚i—~9æ^u«ÍÕU»â0[∞™`∏#Ú|qrà˛˙\5‡Kv£©Ë*VıãóØæy˝ÌÔˇ«Ô˛Ù˝õ∑?\Ω˚Û˚9d∏¯Ò/˝€ﬂˇûåÆ^∆i√˛h?ÈZxjEï@	J∏’≈l˘Òz’~∫πÌ~˛˜˙nûﬁçA-∞»l]ìU pÊŸfª˚œ˛p<›˛Ú_
+ˇ≈/«Üç%U0√√’ç6ò}>FNfæ
+A∑ lH;®∞x˙·’>€¢Ú®ßxﬂÜ‘•}ÿ‚á√@Ã·BÜ–l™ä–Y»ùlF<≥ V»¬(ªæÔ“8ËLR¢?è|¸mq–
+8pöÏúñæm∂!ú!·5°ÚBx˝,»Å∫\S]e!ﬁ£Bª"‰]v&äFÚaë‡°õ
+Mù{ˆ˛‡ó“rèÚk•¶,ï GøπM˛0¯∆¯"dõﬂTWÑÏÚ[ Q{îÖL˝Ù…rHŸp0Å¢|^–Úú†	ÒtT¥:+hp95>5Œ‘-'ÇÆÅ¢¶ùe"•ƒùÜL$o–Q~eQ˘ÕÔ2Ië_3Ç|P.´YõÔ›⁄t9ﬂÕ)W#‰# òu)ÿi»rﬂ?A˝D¢ÄÄÁ9ø·ãtÓFQs1Åa¸Q)©ÁDÿUFø-,…1≤êIÛK§!∞˘Ï–Jìi‰AfÔÁ¡á¶IZüìr=$©kBóıHí¬ÌÀÙÒééâÚ§Õ£ÈÛÙö]‡H‹yÀÈì'¡0VQ^ë˜Ò*2W6Ê†f5)S∞>üÇxXÍwíÃ¶ññ⁄KLm©¸òxø†-ñ`ﬁ ≈¨—ƒ’"ˇ¡¨Ã1r˙2fícç*CÓs	¡óõ2dYÂRÙıs-À†vïW/ÉŒ•åÈNw˝Õâß™*û§F
+$¶≈ÎÕDıµGeRòsÊ’[Ü\Â˚%◊EHQº–◊ô"$/…|:IåÊúH≈XΩp3÷§âëŸÉÙ5ñ√÷ö~GEÍL„…5°ëZËê÷®Ûy!»í§É¢UÛ‚◊©™v¬<°˙¿Zòª %Û‹ym¬O¡∆y’¶òyRÄÃºí≈|›$áErWMM¶(ÇBªÛ>Jù+„⁄ª⁄Ùsg †èπågF≤ÕC‹ôY÷´˛˛õß™¶7“sŸQø~™¶ÎùS\¶®:NZÑ†ÉÂŒ¿ûØ˙úõAˆp«¶VO‘É©®üú—öÁ,i”òGH©9'X¢^~(MIiº∑@©éQJ¨éŒõGúßàx[`#uvEHÓª‘ÿ¨”x~œﬂ»ØãCç⁄´—ƒslY5Ë_øyU]¸OÄ h–&¯
+endstreamendobj296 0 obj[298 0 R]endobj297 0 obj<</Filter/FlateDecode/Length 236>>stream
+Hâ\êMjƒ0Ö˜>Öñ3ã¡é;À`(S
+YÙá¶=Äc+©°±ç‚,r˚*ûa
+ÿ–˚ƒì‰•{Íb( ﬂ)πå!z¬%≠‰úBç\π©˙ªŸf!Ó∑•‡‹≈1â∂˘¡Õ•–áGü<
+˘F)ƒ	_ó˛≤_s˛¡c∆Ä«ëΩÿ¸jgY±SÁπ vbÊœÒπe]us„í«%[ád„Ñ¢U\⁄g.#0˙}}•Ü—}[™Óv+•ïŸ’π©Í¨+{sÌSxY∏Gt+ß´©±ˆ@!‚˝h9e`j‚WÄ "7r;
+endstreamendobj298 0 obj<</BaseFont/YVTYMW+ProximaNova-Bold/CIDSystemInfo 299 0 R/DW 1000/FontDescriptor 300 0 R/Subtype/CIDFontType0/Type/Font/W[0[483]1 2 0 3 4 256 5[125 56]9 10 500 11[250 167 333 623 256]16 17 620 18[411 514 600 587 597]23 24 608 25[545 606 608]28 51 623 52 53 620 54[411 514 582 587 597]59 60 608 61[545 606 608 684 663 687 718 583 571 720 744 731 274 486 636 523 855 729 765 624 765 643 600 582 728 684 918 668 645 592 543]92 93 586 94[499 586 553]97 98 327 99[585 580]101 102 253 103[535 253 298 852 579 574]109 110 585 111[360 477 338 579 513 769 504 513 579 479 597 586 585 626 520 509 616 632 651 258 433 566 468 756 648 655 554 655 573 516 486 646 597 797 584 565 523]148 169 684 170 171 968 172[663]173 177 687 178[718 742 718]181 197 583 198[571]199 203 720 204 208 744 209[748]210 211 731 212 222 274 223 224 760 225[486 636]227 229 523 230[542 537]232 237 729 238 261 765 262[1084 624]264 266 643 267 272 600 273 274 707 275 279 582 280 297 728 298 301 918 302 309 645 310 312 592 313[742 624]315 336 543 337 338 870 339 360 586 361 362 912 363[586]364 368 499 369[690 590 586]372 388 553 389[912 654 907]392 393 580 394[862 580 625]397 399 907 400[952 327]402 406 585 407[584]408 409 580 410 421 253 422[505 506]424 425 253 426 427 535 428 429 253 430[354 384 308]433 434 298 435[354 384 325]438 444 579 445 468 574 469[931 585]471 473 360 474 479 477 480[585 643 327 338 380]485 487 338 488 505 579 506 509 769 510 517 513 518 525 579 526 528 479 529[574 585]531 552 597 553 554 845 555[586]556 560 585 561[626 633 626]564 580 520 581[509 766 977]584 588 616 589 593 632 594[666]595 596 651 597 607 258 608[690 691 433 566]612 614 468 615[499 479]617 622 648 623 646 655 647[929 554]649 651 573 652 657 516 658 659 620 660[1032]661 665 486 666 683 646 684 687 797 688 695 565 696 698 523 699[633 554 251]702 703 0 704[251]705 706 0 707[251 300]709 710 0 711[300 0 338]714 715 0 716[423 0 159]719 720 0 721[249 0 327]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[221 0 220]739 743 0 744[255 684 663 571]748 749 684 750[583 592 731 765 274 636 684 855 729 624 765 731 624 586 582 645 855 668 866]769 770 765 771[600 586 513 574 489 486 579 574 267 535 513]782 783 593 784[513 486 574 631 583 492 574 472 577 706 504 739 782 684 666 815 358 814 779 813 274 645 600 489 579]809 811 267 812 814 577 815[574 782 541]818 819 143 820[453]821 822 163 823[255 684 624 663 571 734]829 830 583 831[951 610]833 834 729 835[636 731 855 731 765 731 624 687 582 645 855 668 743 649 983 1014 778 867 624 687 1043 643 776 571 687 600]861 862 274 863[486]864 865 1081 866[807 636 645 711 754 951 729 636 684 855 543 586 574 559 454 588]882 883 553 884[747 489]886 887 580 888[535 580 711 580 574 580 585 499 432 513 706 504 578 564 823 836 643 776 553 508 809 567 584 454 508 477]914 916 253 917 918 880 919[584 535 513 570 586 478 585 747 459]928 929 579 930[535 513 580 579 852 564 587 852 861 643 553 809 574 454 588 580 432 763 596 760 588 624 557 624 585 571 454 571 454 640 585 999 799 610 489 669 582 696 597 636 539 933 736 763 588 1028 781 1097 912 905 726 687 499 582 432 645 513 644 513 710 551 897 668 680 573 649 564 649 580 926 700 926 700 274 634 535 763 588 731 580 763 588 649 564 886 719 253 684 543 586 684 543 586 968 870 912 583 553 744 553 744 553 951 747 610 489 610 444 729 580 729 580 765 574 765 574 765 574 687 508 645 513 645 513 645 513 649 564 571 454 867 776 668 504 610 489 731 580 918 769 763 588 697 588 763 588 649 584 649 564 645 513 687 508 684 543 586 583 553 583 553 583 553 610 489 765 574 765 574 765 574 765 574 867 776 687 508 687 508 687 508 643 567 643 567 1043 809 1043 809 729 580 867 776 610 489 583 553 729 579 765 574 951 747 571 454 668 504 645 513 684 543 586 583 553 729 580 765 574 645 513 867 776 687 508 1043 809 643 567 583 553 1043 809 765 574 744 553 765 574 624 585 610 489 763 588 571 454 687 499 744 553]1180 1185 0 1186[646 567 618 517 783 757 613 1122 905]1195 1198 297 1199 1202 280 1203 1206 288 1207 1209 351 1210[484 449 256 768 251]1215 1220 256 1221 1222 239 1223[456 398 456]1226 1227 396 1228[467 398 456]1231 1232 396 1233[406 225]1235 1236 459 1237 1240 255 1241[459 256]1243 1246 527 1247 1250 337 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 256 1262 1263 358 1264[614 516]1266 1267 499 1268[585 550 449 645 565 709 610 454 397 623 696 585 580 550 747 677 1107 1228 918 845 588 532 545 624 583 582 623 494]1296 1297 778 1298[454 476 526 1134 842]1303 1304 329 1305[441 564 510]1308 1309 216 1310 1312 504 1313[511 256]1315 1321 504 1322[515 504 373 682 690 574 586 788 375 311 238 429]1334 1335 385 1336[413 414 391]1339 1340 411 1341[184 192 596 412]1345 1346 405 1347[258 336 235 397 286]1352 1356 397 1357[371]1358 1359 397 1360 1361 192 1362[312 157 383 183 158 397 286]1369 1373 397 1374[371]1375 1376 397 1377 1378 192 1379[312 157 383 183 158 397 286]1386 1390 397 1391[371]1392 1393 397 1394 1395 159 1396[397 286]1398 1402 397 1403[371]1404 1405 397 1406[860 810 903 860 953 860]1412 1413 953 1414[877]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj299 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj300 0 obj<</Ascent 1079/CIDSet 301 0 R/CapHeight 667/Descent -368/Flags 4/FontBBox[-385 -368 1196 1079]/FontFamily(Proxima Nova)/FontFile3 302 0 R/FontName/YVTYMW+ProximaNova-Bold/FontStretch/Normal/FontWeight 700/ItalicAngle 0/StemV 128/Type/FontDescriptor/XHeight 483>>endobj301 0 obj<</Filter/FlateDecode/Length 15>>stream
+Hâö¿   Y —
+endstreamendobj302 0 obj<</Filter/FlateDecode/Length 404/Subtype/CIDFontType0C>>stream
+Hâbd`ab`ddîàâÙ◊( Ø»ÃMÙÀ/K‘u œI…È˛ê˛!”Õ#˜CñÒáÀ9—?¢XdX÷¸:ÕzñGÈ{0ˇ˜¡Ô<™ﬂ?®0∞22≤Òπá§8¶‰'•z¶§ÊïdñT:ÁTe¶gî(ƒh$«h*¯&e+gÊÊÁÁÁÈ(òÍ)8Ê‰(Ä+•ßï•¶ËÈªáT§*ò(§§¶a8ò¿4#£öfﬂèr√ï?≠d<ªÍ˚ñ’Ã?LEﬁ˚˝˘Ô=ˆÔóWä˛ﬁÚs—˜-l|ﬂß˝‘Ó˛Œ˚›à’øÛ
+ù˝ÆÙ} w’ﬂﬂUÖø¸p˚.|Óˆ˚˚A\¶…ˇ85cˇ·˚ROºÓ¸ñ•œˆ]È«6—ÔnlªWf'%‰ÊDÀˇvc˚ÕÀ"¸Âª7€·ïÈâ—Ÿ9°ÚøΩŸ¯@a«˘CûGm◊˜øBu3~îO?4˝À¥Ô,≥Ÿ~óÕû9ù]nÅôÈÃôˇy8ªy∏7p}„ﬁph¬ûÔb3yx T£•f
+endstreamendobj303 0 obj[305 0 R]endobj304 0 obj<</Filter/FlateDecode/Length 227>>stream
+Hâ\ê¡j√0ÜÔ~
+€C±õ]C`trÿZñÌ[IãlÁê∑ü‚Ö&∞A˛ˇO¸ñæ¥/-Ö˙∆—uòa‰Á∏∞CËq§Œ¯‡Úﬁï€M6)-p∑ŒßñÜ®ÍÙáàsÊœ>ˆxT˙ 9–áØKw›-)}„Ñî¡@”Ä«AΩŸÙn']∞SÎEy=	ÛÁ¯\BU˙Ûo=Œ…:dK#™⁄H5PøJ5
+…ˇ”w™‹›rq?â€ò ˜˛æqÚ=xÑr≥‰);(A∂Å±¶µı#¿ †oë
+endstreamendobj305 0 obj<</BaseFont/QJSCEM+ProximaNova-Semibold/CIDSystemInfo 306 0 R/DW 1000/FontDescriptor 307 0 R/Subtype/CIDFontType0/Type/Font/W[0[493]1 2 0 3 4 257 5[125 56]9 10 500 11[250 167 333 612 245]16 17 616 18[380 474 595 574 580 600 601 532 595 601]28 51 612 52 53 616 54[380 474 580 574 580 600 601 532 595 601 673 648 682 710 577 562 717 745 723 259 481 621 517 835 720 765 608 765 628 594 577 719 673 903 661 637 589 536]92 93 581 94[497 581 557]97 98 308 99[580 568]101 102 241 103[526 241 285 833 567 573]109 110 580 111[347 472 319 567 503 754 496 503 567 476 586 572 584 621 515 501 620 636 644 245 428 552 464 740 641 658 540 658 561 511 480 636 586 783 577 557 520]148 169 673 170 171 959 172[648]173 177 682 178[710 736 710]181 197 577 198[562]199 203 717 204 208 745 209[741]210 211 723 212 222 259 223 224 740 225[481 621]227 230 517 231[533]232 237 720 238 261 765 262[1093 608]264 266 628 267 272 594 273 274 690 275 279 577 280 297 719 298 301 903 302 309 637 310 312 589 313[736 608]315 336 536 337 338 878 339 360 581 361 362 922 363[581]364 368 497 369[670 585 581]372 388 557 389[889 616 876]392 393 549 394[834 549 593]397 399 857 400[901 308]402 406 580 407[571]408 409 568 410 421 241 422 423 482 424 425 241 426 427 526 428 429 241 430[327 351 299]433 434 285 435[327 351 314]438 444 567 445 468 573 469[944 580]471 473 347 474 479 472 480[581 623 308 319 351]485 487 319 488 505 567 506 509 754 510 517 503 518 525 567 526 528 476 529[573 580]531 552 586 553 554 835 555[572]556 560 584 561[621 631 621]564 580 515 581[501 746 965]584 588 620 589 593 636 594[661]595 596 644 597 607 245 608 609 673 610[428 552]612 614 464 615[487 480]617 622 641 623 646 658 647[939 540]649 651 561 652 657 511 658 659 609 660[1022]661 665 480 666 683 636 684 687 783 688 695 557 696 698 520 699[631 540 240]702 703 0 704[240]705 706 0 707[240 285]709 710 0 711[285 0 324]714 715 0 716[419 0 147]719 720 0 721[243 0 321]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[214 0 206]739 743 0 744[244 673 648 562]748 749 673 750[577 589 723 765 259 621 673 835 720 620 765 723 608 581 577 637 834 661 836]769 770 765 771[595 581 503 573 484 487 567 573 255 526 503]782 783 581 784[503 487 573 610 578 488 573 466 570 685 496 713 772 673 639 785 321 797 749 787 259 637 595 484 567]809 811 255 812 814 570 815[573 772 526]818 819 133 820[424]821 822 153 823[244 673 608 648 562 722]829 830 577 831[933 599]833 834 720 835[621 723 835 723 765 723 608 682 577 637 834 661 732 631 953 982 767 832 608 682 1015 628 764 562 682 594]861 862 259 863[481]864 865 1072 866[790 621 637 703 742 933 720 621 673 834 536 581 572 548 452 571]882 883 557 884[727 484]886 887 568 888[526 568 697 568 573 568 580 497 418 503 685 496 561 550 791 804 628 750 540 511 789 561 571 452 511 472]914 916 241 917 918 867 919[571 526 503 558 581 472 580 727 454]928 929 567 930[526 503 568 567 833 550 570 833 836 628 540 789 573 452 571 568 418 763 590 749 571 608 543 608 580 562 452 562 452 618 580 966 765 599 484 643 563 681 588 621 529 924 737 752 571 1026 779 1082 907 913 714 682 497 577 418 637 503 636 503 696 539 891 649 660 553 631 550 631 568 923 702 923 702 259 618 526 752 571 723 568 752 571 631 550 864 700 241 673 536 581 673 536 581 959 878 922 577 557 745 557 745 557 933 727 599 484 599 434 720 568 720 568 765 573 765 573 765 573 682 511 637 503 637 503 637 503 631 550 562 452 832 750 661 496 599 484 723 568 903 754 752 571 678 571 752 571 631 571 631 550 637 503 682 511 673 536 581 577 557 577 557 577 557 599 484 765 573 765 573 765 573 765 573 832 750 682 511 682 511 682 511 628 561 628 561 1015 789 1015 789 720 568 832 750 599 484 577 557 720 567 765 573 933 727 562 452 661 496 637 503 673 536 581 577 557 720 568 765 573 637 503 832 750 682 511 1015 789 628 561 577 557 1015 789 765 573 745 557 765 573 608 580 599 484 752 571 562 452 682 497 745 557]1180 1185 0 1186[643 562 606 508 783 746 604 1105 893]1195 1198 276 1199 1202 264 1203 1206 276 1207 1209 346 1210[477 449 245 734]1214 1222 245 1223[458 396 458]1226 1227 396 1228[470 396 458]1231 1232 396 1233[379 214]1235 1236 429 1237 1240 244 1241[430 245]1243 1246 489 1247 1250 319 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 245 1262 1263 358 1264[605 511]1266 1267 497 1268[584 536 439 637 557 703 610 444 384 612 689 584 572 536 739 661 1090 1208 903 834 585]1289 1290 527 1291[608 568 577 612 494]1296 1297 778 1298[454 476 504 1125 842]1303 1304 315 1305[437 564 507]1308 1309 214 1310 1312 502 1313[511 245]1315 1321 502 1322[510 502 362 700 675 573 581 753 375 302 228 404]1334 1335 382 1336[411 412 394]1339 1340 405 1341[174 186 585 406]1345 1346 405 1347[250 333 222 393 264]1352 1356 393 1357[367]1358 1359 393 1360 1361 179 1362[310 149 377 183 151 393 264]1369 1373 393 1374[367]1375 1376 393 1377 1378 179 1379[310 149 377 183 151 393 264]1386 1390 393 1391[367]1392 1393 393 1394 1395 150 1396[393 264]1398 1402 393 1403[367]1404 1405 393 1406[832 782 886 832 936 832]1412 1413 936 1414[860]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj306 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj307 0 obj<</Ascent 1079/CIDSet 308 0 R/CapHeight 667/Descent -355/Flags 4/FontBBox[-373 -355 1170 1079]/FontFamily(Proxima Nova Semibold)/FontFile3 309 0 R/FontName/QJSCEM+ProximaNova-Semibold/FontStretch/Normal/FontWeight 600/ItalicAngle 0/StemV 104/Type/FontDescriptor/XHeight 483>>endobj308 0 obj<</Filter/FlateDecode/Length 11>>stream
+Hâö `  ë ë
+endstreamendobj309 0 obj<</Filter/FlateDecode/Length 306/Subtype/CIDFontType0C>>stream
+Hâbd`ab`ddî	Ù
+vvı’( Ø»ÃMÙÀ/K‘NÕÕL œI…Î˛ê˛!”Õ#˜CñÒáÀy—?úøøÀ∞L˙uöµüGÈ{
+ˇ˜,¡ÔÈ<™ﬂg®0∞12≤Òπ˚«8¶‰'•z¶§ÊïdñT:ÁTe¶gî(ƒh$«h*¯&e+gÊÊÁÁÁÈ(òÍ)8Ê‰(Ä+•ßï•¶ËÅ‚tàæ[pHeA™ÇâBJjVó3à`bdT”¸—h∏ÚÁ¢ïåóV}ﬂ≤ö˘áï°Ëœ{ø?ˇΩ«˛˝ÚJ—ﬂ[~.˙æÖçÔ˚T>êˇ8(®Ì¯æT®n∆èÚÈá¶ôˆùe6€Ô≤Ÿ3ß≥À-03ù9Û?g7˜:Æo‹ÎvLò¬√Ûm/@Ä ﬂw9
+endstreamendobj310 0 obj[312 0 R]endobj311 0 obj<</Filter/FlateDecode/Length 227>>stream
+Hâ\ê¡j√0ÜÔ~
+€C±õ]C`trÿZñÌ[IãlÁê∑ü‚Ö&∞A˛ˇO¸ñæ¥/-Ö˙∆—uòa‰Á∏∞CËq§Œ¯‡Úﬁï€M6)-p∑ŒßñÜ®ÍÙáàsÊœ>ˆxT˙ 9–áØKw›-)}„Ñî¡@”Ä«AΩŸÙn']∞SÎEy=	ÛÁ¯\BU˙Ûo=Œ…:dK#™⁄H5PøJ5
+…ˇ”w™‹›rq?â€ò ˜˛æqÚ=xÑr≥‰);(A∂Å±¶µı#¿ †oë
+endstreamendobj312 0 obj<</BaseFont/HLJAIE+ProximaNova-Medium/CIDSystemInfo 313 0 R/DW 1000/FontDescriptor 314 0 R/Subtype/CIDFontType0/Type/Font/W[0[500]1 2 0 3 4 258 5[125 56]9 10 500 11[250 167 333 605 238]16 17 614 18[359 449 591 565 569 595 596 523 588 596]28 51 605 52 53 614 54[359 449 579 565 569 595 596 523 588 596 666 638 679 705 573 556 715 746 717 249 478 611 513 822 714 765 597 765 618 590 573 710 666 893 656 632 587 532]92 93 578 94[496 578 560]97 98 296 99[577 560]101 102 233 103[520 233 277 820 559 572]109 110 577 111[338 468 306 559 497 744 491 497 559 474 579 563 583 618 512 496 623 639 640 237 425 543 461 729 636 660 531 660 553 508 476 629 579 773 572 552 518]148 169 666 170 171 953 172[638]173 177 679 178[705 732 705]181 197 573 198[556]199 203 715 204 208 746 209[736]210 211 717 212 222 249 223 224 727 225[478 611]227 230 513 231[531]232 237 714 238 261 765 262[1099 597]264 266 618 267 272 590 273 274 681 275 279 573 280 297 710 298 301 893 302 309 632 310 312 587 313[732 597]315 336 532 337 338 883 339 360 578 361 362 929 363[578]364 368 496 369[657 581 578]372 388 560 389[874 591 856]392 393 529 394[816 529 572]397 399 824 400[868 296]402 406 577 407[562]408 409 560 410 421 233 422 423 466 424 425 233 426 427 520 428 429 233 430[309 329 293]433 434 277 435[310 329 306]438 444 559 445 468 572 469[953 577]471 473 338 474 479 468 480[569 605 296 306 332]485 487 306 488 505 559 506 509 744 510 517 497 518 525 559 526 528 474 529[572 577]531 552 579 553 554 828 555[563]556 560 583 561[618 628 618]564 580 512 581[496 733 957]584 588 623 589 593 639 594[658]595 596 640 597 607 237 608 609 662 610[425 543]612 614 461 615[479 481]617 622 636 623 646 660 647[946 531]649 651 553 652 657 508 658 659 603 660[1015]661 665 476 666 683 629 684 687 773 688 695 552 696 698 518 699[628 531 233]702 703 0 704[233]705 706 0 707[233 275]709 710 0 711[275 0 315]714 715 0 716[416 0 137]719 720 0 721[239 0 317]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[209 0 200]739 743 0 744[237 666 638 556]748 749 666 750[573 587 717 765 249 611 666 822 714 618 765 717 597 578 573 632 820 656 816]769 770 765 771[592 578 497 572 485 488 559 572 247 520 497]782 783 573 784[497 488 572 596 575 485 572 462 566 688 491 710 772 666 631 775 307 791 737 783 249 632 592 485 559]809 811 247 812 814 566 815[572 772 520]818 819 128 820[407]821 822 148 823[237 666 597 638 556 720]829 830 573 831[921 592]833 834 714 835[611 717 822 717 765 717 597 679 573 632 820 656 728 621 956 984 760 810 597 679 1003 618 767 556 679 590]861 862 249 863[478]864 865 1066 866[787 611 632 699 746 921 714 611 666 820 532 578 573 544 444 566]882 883 560 884[718 485]886 887 560 888[520 560 684 560 572 560 577 496 410 497 684 491 557 546 787 801 619 731 531 513 778 554 562 444 513 468]914 916 233 917 918 858 919[562 520 497 551 578 469 577 718 455]928 929 559 930[520 497 560 559 820 546 565 820 826 619 531 778 572 444 566 560 410 766 590 746 566 597 534 597 577 556 444 556 444 612 577 948 749 592 485 629 550 663 574 611 522 918 731 746 566 1025 771 1080 904 899 703 679 496 573 410 632 497 631 497 685 527 890 645 649 551 621 546 621 560 916 697 916 697 249 608 520 741 566 717 560 741 566 621 546 854 690 233 666 532 578 666 532 578 953 883 929 573 560 746 560 746 560 921 718 592 485 592 433 714 560 714 560 765 572 765 572 765 572 679 513 632 497 632 497 632 497 621 546 556 444 810 731 656 491 592 485 717 560 893 744 746 566 668 566 746 566 621 562 621 546 632 497 679 513 666 532 578 573 560 573 560 573 560 592 485 765 572 765 572 765 572 765 572 810 731 679 513 679 513 679 513 618 554 618 554 1003 778 1003 778 714 560 810 731 592 485 573 560 714 559 765 572 921 718 556 444 656 491 632 497 666 532 578 573 560 714 560 765 572 632 497 810 731 679 513 1003 778 618 554 573 560 1003 778 765 572 746 560 765 572 597 577 592 485 746 566 556 444 679 496 746 560]1180 1185 0 1186[642 559 598 502 783 739 598 1094 885]1195 1198 262 1199 1202 254 1203 1206 268 1207 1209 343 1210[472 449 238 712]1214 1222 238 1223[460 395 460]1226 1227 396 1228[470 395 460]1231 1232 396 1233[361 206]1235 1236 409 1237 1240 237 1241[410 238]1243 1246 464 1247 1250 307 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 238 1262 1263 358 1264[599 508]1266 1267 496 1268[583 527 432 632 552 699 610 438 375 605 685 583 567 527 734 650 1079 1195 893 827 582 524 521 597 569 573 605 494]1296 1297 778 1298[454 476 490 1119 842]1303 1304 306 1305[434 564 505]1308 1309 212 1310 1312 500 1313[511 238]1315 1321 500 1322[507 500 355 712 665 572 578 730 375 296 215 381]1334 1335 380 1336[410 411 396]1339 1340 401 1341[168 182 578 402]1345 1346 405 1347[245 331 214 390 250]1352 1356 390 1357[365]1358 1359 390 1360 1361 170 1362[309 144 373 183 147 390 250]1369 1373 390 1374[365]1375 1376 390 1377 1378 170 1379[309 144 373 183 147 390 250]1386 1390 390 1391[365]1392 1393 390 1394 1395 144 1396[390 250]1398 1402 390 1403[365]1404 1405 390 1406[815 765 875 815 925 815]1412 1413 925 1414[850]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj313 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj314 0 obj<</Ascent 1079/CIDSet 315 0 R/CapHeight 667/Descent -340/Flags 4/FontBBox[-365 -340 1153 1079]/FontFamily(Proxima Nova Medium)/FontFile3 316 0 R/FontName/HLJAIE+ProximaNova-Medium/FontStretch/Normal/FontWeight 500/ItalicAngle 0/StemV 92/Type/FontDescriptor/XHeight 483>>endobj315 0 obj<</Filter/FlateDecode/Length 11>>stream
+Hâö `  ë ë
+endstreamendobj316 0 obj<</Filter/FlateDecode/Length 297/Subtype/CIDFontType0C>>stream
+Hâbd`ab`ddîÚÒrÙt’( Ø»ÃMÙÀ/K‘ıMM…,Õ…Í˛ê˛!”Õ#˜CñÒá8À9—?åø_»∞4˛:Õ⁄œ£Ù=úˇ{¨‡˜(’Ô›<*¨åål|Ó!ié)˘I©û)©y%ô%ïŒ˘ïEôÈ%
+1…1ö
+æâEŸ
+¡ôπ˘y≈˘y:
+F¶z
+é99
+`E≈
+E©≈©Ee©)z˙n¡!ï©
+&
+)©iXúÃ ÇâëQMÛGá· üãV2^]ı}ÀjÊ∂Ü¢?Ô˝˛¸˜˚˜À+Eo˘πË˚6æÔ”¯@û‚¸!œ£∂„˚°∫? ßö˛e⁄wñŸløÀfœúŒ.∑¿ÃtÊÃˇ<ú›<‹k∏ûsØŸ–?âáÁ˘^Ä  ≠;qÅ
+endstreamendobj317 0 obj[319 0 R]endobj318 0 obj<</Filter/FlateDecode/Length 227>>stream
+Hâ\ê¡j√0ÜÔ~
+€C±õ]C`trÿZñÌ[IãlÁê∑ü‚Ö&∞A˛ˇO¸ñæ¥/-Ö˙∆—uòa‰Á∏∞CËq§Œ¯‡Úﬁï€M6)-p∑ŒßñÜ®ÍÙáàsÊœ>ˆxT˙ 9–áØKw›-)}„Ñî¡@”Ä«AΩŸÙn']∞SÎEy=	ÛÁ¯\BU˙Ûo=Œ…:dK#™⁄H5PøJ5
+…ˇ”w™‹›rq?â€ò ˜˛æqÚ=xÑr≥‰);(A∂Å±¶µı#¿ †oë
+endstreamendobj319 0 obj<</BaseFont/UPVAIE+ProximaNova-Regular/CIDSystemInfo 320 0 R/DW 1000/FontDescriptor 321 0 R/Subtype/CIDFontType0/Type/Font/W[0[507]1 2 0 3 4 258 5[125 56]9 10 500 11[250 167 333 598 230]16 17 612 18[339 424 588 557 558 590 591 515 581 591]28 51 598 52 53 612 54[339 424 578 557 558 590 591 515 581 591 658 629 676 700 569 550 713 747 712 239 475 601 510 809 708 765 587 765 608 586 570 700 658 883 652 626 585 527]92 93 575 94[495 575 563]97 98 283 99[574 552]101 102 225 103[514 225 268 808 551 572]109 110 574 111[330 465 294 551 490 734 486 490 551 472 572 554 582 615 509 491 626 642 635 229 422 534 458 719 632 662 522 662 545 504 472 623 572 764 567 547 516]148 169 658 170 171 947 172[629]173 177 676 178[700 728 700]181 197 569 198[550]199 203 713 204 208 747 209[731]210 211 712 212 222 239 223[713 714 475 601]227 230 510 231[529]232 237 708 238 261 765 262[1105 587]264 266 608 267 272 586 273 274 672 275 279 570 280 297 700 298 301 883 302 309 626 310 312 585 313[728 587]315 336 527 337 338 889 339 360 575 361 362 936 363[575]364 368 495 369[644 577 575]372 388 563 389[858 566 835]392 393 509 394[797 509 551]397 399 792 400[835 283]402 406 574 407[554]408 409 552 410 421 225 422[451 450]424 425 225 426 427 514 428 429 225 430[291 307 287]433 434 268 435[293 307 299]438 444 551 445 468 572 469[962 574]471 473 330 474 479 465 480[557 587 283 294 313]485 487 294 488 505 551 506 509 734 510 517 490 518 525 551 526 528 472 529[572 574]531 552 572 553 554 821 555[554]556 560 582 561[615 626 615]564 580 509 581[491 720 949]584 588 626 589 593 642 594[655]595 596 635 597 607 229 608[650 651 422 534]612 614 458 615[472 481]617 622 632 623 646 662 647[953 522]649 651 545 652 657 504 658 659 597 660[1008]661 665 472 666 683 623 684 687 764 688 695 547 696 698 516 699[626 522 226]702 703 0 704[226]705 706 0 707[226 265]709 710 0 711[265 0 305]714 715 0 716[413 0 127]719 720 0 721[236 0 313]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[205 0 194]739 743 0 744[230 658 629 550]748 749 658 750[569 585 712 765 239 601 658 809 708 615 765 712 587 575 570 626 806 652 796]769 770 765 771[589 575 490 572 485 489 551 572 239 514 490]782 783 565 784[490 489 572 582 572 483 572 458 562 691 486 708 771 658 623 766 293 785 725 779 239 626 589 485 551]809 811 239 812 814 562 815[572 771 514]818 819 123 820[390]821 822 143 823[230 658 587 629 550 717]829 830 569 831[909 584]833 834 708 835[601 712 809 712 765 712 587 676 570 626 806 652 723 611 958 986 752 788 587 676 992 608 769 550 676 586]861 862 239 863[475]864 865 1060 866[785 601 626 696 751 909 708 601 658 806 527 575 574 540 436 561]882 883 563 884[708 485]886 887 552 888[514 552 671 552 572 552 574 495 402 490 683 486 552 541 783 798 610 712 522 516 767 547 554 436 516 465]914 916 225 917 918 849 919[554 514 490 544 575 465 574 708 455]928 929 551 930[514 490 552 551 808 541 560 808 816 610 522 767 572 436 561 552 402 768 590 743 561 587 524 587 574 550 436 550 436 606 574 931 733 584 485 614 537 645 559 601 516 913 725 739 561 1024 763 1079 901 885 692 676 495 570 402 626 490 626 490 674 515 889 640 638 550 611 541 611 552 908 692 908 692 239 598 514 729 561 712 552 729 561 611 541 844 680 225 658 527 575 658 527 575 947 889 936 569 563 747 563 747 563 909 708 584 485 584 431 708 552 708 552 765 572 765 572 765 572 676 516 626 490 626 490 626 490 611 541 550 436 788 712 652 486 584 485 712 552 883 734 739 561 658 561 739 561 611 554 611 541 626 490 676 516 658 527 575 569 563 569 563 569 563 584 485 765 572 765 572 765 572 765 572 788 712 676 516 676 516 676 516 608 547 608 547 992 767 992 767 708 552 788 712 584 485 569 563 708 551 765 572 909 708 550 436 652 486 626 490 658 527 575 569 563 708 552 765 572 626 490 788 712 676 516 992 767 608 547 569 563 992 767 765 572 747 563 765 572 587 574 584 485 739 561 550 436 676 495 747 563]1180 1185 0 1186[641 556 590 496 783 731 592 1083 878]1195 1198 248 1199 1202 243 1203 1206 260 1207 1209 340 1210[468 449 230 690]1214 1222 230 1223[462 394 462]1226 1227 396 1228[471 394 462]1231 1232 396 1233[343 199]1235 1236 390 1237 1240 230 1241[390 230]1243 1246 439 1247 1250 295 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 230 1262 1263 358 1264[593 504]1266 1267 495 1268[582 518 425 626 547 695 610 431 367 598 680 582 561 518 729 640 1067 1183 883 820 579 520 516 587 571 570 598 494]1296 1297 778 1298[454 476 475 1113 842]1303 1304 296 1305[432 564 503]1308 1309 211 1310 1312 499 1313[511 230]1315 1321 499 1322[504 499 348 725 656 572 575 707 375 290 203 358]1334 1335 378 1336[409 410]1338 1340 398 1341[161 178 571 398]1345 1346 405 1347[240 330 206 388 235]1352 1356 388 1357[362]1358 1359 388 1360 1361 161 1362[307 139 370 183 142 388 235]1369 1373 388 1374[362]1375 1376 388 1377 1378 161 1379[307 139 370 183 142 388 235]1386 1390 388 1391[362]1392 1393 388 1394 1395 138 1396[388 235]1398 1402 388 1403[362]1404 1405 388 1406[796 746 864 796 914 796]1412 1413 914 1414[838]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj320 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj321 0 obj<</Ascent 1079/CIDSet 322 0 R/CapHeight 667/Descent -325/Flags 4/FontBBox[-356 -325 1136 1079]/FontFamily(Proxima Nova)/FontFile3 323 0 R/FontName/UPVAIE+ProximaNova-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 76/Type/FontDescriptor/XHeight 483>>endobj322 0 obj<</Filter/FlateDecode/Length 11>>stream
+Hâö `  ë ë
+endstreamendobj323 0 obj<</Filter/FlateDecode/Length 298/Subtype/CIDFontType0C>>stream
+Hâbd`ab`ddîsÙt’( Ø»ÃMÙÀ/K‘JM/ÕI,IÎ˛ê˛!”Õ#˜CñÒáÀ9—ﬂ?~ﬂîa)¯uöµüGÈ{$ˇ˜x¡Ô1<™ﬂ{yTXŸ¯‹C“SÚìR=SRÛJ2K*ùÛ*ã2”3Jb4íc4|ã≤Ç3sÛÛäÛÛtåLısr¿äääRãSã RSÙÙ›ÇC*RLRR”∞πòA#£öÊè~√ï?≠dºπÍ˚ñ’Ã?Eﬁ˚˝˘Ô=ˆÔóWä˛ﬁÚs—˜-l|ﬂßÒÅ|≈˘CûGm«˜YBu3~îO?4˝À¥Ô,≥Ÿ~óÕû9ù]nÅôÈÃôˇy8ªy∏Ws›‡^Ω¨œçI<º  °œsD
+endstreamendobj324 0 obj[326 0 R]endobj325 0 obj<</Filter/FlateDecode/Length 227>>stream
+Hâ\ê¡j√0ÜÔ~
+€C±õ]C`trÿZñÌ[IãlÁê∑ü‚Ö&∞A˛ˇO¸ñæ¥/-Ö˙∆—uòa‰Á∏∞CËq§Œ¯‡Úﬁï€M6)-p∑ŒßñÜ®ÍÙáàsÊœ>ˆxT˙ 9–áØKw›-)}„Ñî¡@”Ä«AΩŸÙn']∞SÎEy=	ÛÁ¯\BU˙Ûo=Œ…:dK#™⁄H5PøJ5
+…ˇ”w™‹›rq?â€ò ˜˛æqÚ=xÑr≥‰);(A∂Å±¶µı#¿ †oë
+endstreamendobj326 0 obj<</BaseFont/DFGCEM+ProximaNova-Light/CIDSystemInfo 327 0 R/DW 1000/FontDescriptor 328 0 R/Subtype/CIDFontType0/Type/Font/W[0[517]1 2 0 3 4 259 5[125 56]9 10 500 11[250 167 333 588 219]16 17 608 18[308 387 582 544 541 582 584 502 571 584]28 51 588 52 53 608 54[308 387 576 544 541 582 584 502 571 584 647 614 672 692 564 542 711 748 703 223 470 586 504 790 699 764 571 764 594 581 564 686 647 867 645 618 581 521]92 93 571 94[494 571 567]97 98 265 99[570 540]101 102 214 103[505 214 256 789 540 571]109 110 570 111[317 459 275 540 481 719 479 481 540 469 562 541 581 611 505 484 630 647 629 216 417 521 454 703 625 666 509 666 533 499 465 613 562 749 560 539 513]148 169 647 170 171 939 172[614]173 177 672 178[692 721 692]181 197 564 198[542]199 203 711 204 208 748 209[724]210 211 703 212 222 223 223 224 693 225[470 586]227 230 504 231[526]232 237 699 238 261 764 262[1115 571]264 266 594 267 272 581 273 274 658 275 279 564 280 297 686 298 301 867 302 309 618 310 312 581 313[721 571]315 336 521 337 338 897 339 360 571 361 362 947 363[571]364 368 494 369[625 572 571]372 388 567 389[835 529 805]392 393 478 394[770 478 520]397 399 743 400[785 265]402 406 570 407[541]408 409 540 410 421 214 422[427 428]424 425 214 426 427 505 428 429 214 430[264 273 277]433 434 256 435[268 273 287]438 444 540 445 468 571 469[975 570]471 473 317 474 479 459 480[540 561 265 275 285]485 487 275 488 505 540 506 509 719 510 517 481 518 525 540 526 528 469 529[571 570]531 552 562 553 554 811 555[541]556 560 581 561[611 622 611]564 580 505 581[484 700 937]584 588 630 589 593 647 594[650]595 596 629 597 607 216 608 609 633 610[417 521]612 614 454 615[460 482]617 622 625 623 646 666 647[964 509]649 651 533 652 657 499 658 659 589 660[998]661 665 465 666 683 613 684 687 749 688 695 539 696 698 513 699[622 509 216]702 703 0 704[216]705 706 0 707[216 250]709 710 0 711[250 0 291]714 715 0 716[409 0 113]719 720 0 721[230 0 307]724 725 0 726[363]727 728 0 729 730 363 731[351]732 735 0 736[198 0 185]739 743 0 744[219 647 614 542]748 749 647 750[564 581 703 764 223 586 647 790 699 612 764 703]762 763 571 764[564 618 785 645 766]769 770 764 771[585 571 481 571 486 491 540 571 228 505 481]782 783 554 784[481 491 571 561 567 479 571 453 555 696 479 704 771 647 612 751 271 775 707 772 223 618 585 486 540]809 811 228 812 814 555 815[571 771 505]818 819 116 820[364]821 822 136 823[219 647 571 614 542 714]829 830 564 831[892 573]833 834 699 835[586 703 790 703 764 703 571 672 564 618 785 645 717 595 962 988 741 754 571 672 974 594 773 542 672 581]861 862 223 863[470]864 865 1051 866[781 586 618 690 757 892 699 586 647 785 521 571 576 533 425 553]882 883 567 884[694 486]886 887 540 888[505 540 652 540 571 540 570 494 391 481 682 479 546 535 777 793 597 684 509 519 750 537 541 425 519 459]914 916 214 917 918 836 919[541 505 481 533 571 460 570 694 456]928 929 540 930[505 481]932 933 540 934[789 535 553 789 802 597 509 750 571 425 553 540 391 772 590 739 553 571 510 571 570 542 425 542 425 596 570 904 709 573 486 593 518 618 538 586 506 904 716 730 553 1022 751 1076 897 865 676 672 494 564 391 618 481 618 481 658 498 887 634 622 547 595 535 595 540 897 685 897 685 223 582 505 712 553 703 540 712 553 595 535 830 664 214 647 521 571 647 521 571 939 897 947 564 567 748 567 748 567 892 694 573 486 573 429 699 540 699 540 764 571 764 571 764 571 672 519 618 481 618 481 618 481 595 535 542 425 754 684 645 479 573 486 703 540 867 719 730 553 642 553 730 553 595 541 595 535 618 481 672 519 647 521 571 564 567 564 567 564 567 573 486 764 571 764 571 764 571 764 571 754 684 672 519 672 519 672 519 594 537 594 537 974 750 974 750 699 540 754 684 573 486 564 567 699 540 764 571 892 694 542 425 645 479 618 481 647 521 571 564 567 699 540 764 571 618 481 754 684 672 519 974 750 594 537 564 567 974 750 764 571 748 567 764]1167 1168 571 1169[570 573 486 730 553 542 425 672 494 748 567]1180 1185 0 1186[639 552 579 488 783 720 582 1067 866]1195 1198 227 1199 1202 228 1203 1206 249 1207 1209 335 1210[461 449 219 657]1214 1222 219 1223[464 393 464]1226 1227 397 1228[471 393 464]1231 1232 397 1233[317 187]1235 1236 360 1237 1240 219 1241[361 219]1243 1246 402 1247 1250 277 1251 1253 300 1254 1256 593 1257 1258 833 1259 1261 219 1262 1263 358 1264[584 499]1266 1267 494 1268[581 505 415 618 539 690 610 422 354 588 674 581 553 505 722 624 1050 1164 867 810 574 515 507 571 573 564 588 494]1296 1297 778 1298[454 476 454 1104 842]1303 1304 282 1305[428 564 499]1308 1309 208 1310 1312 496 1313[511 219]1315 1321 496 1322[499 496 337 743 641]1327 1328 571 1329[673 375 282 184 324]1334 1335 375 1336[408 409 401]1339 1340 392 1341[152 172 561 393]1345 1346 405 1347[233 327 193 384 214]1352 1356 384 1357[359]1358 1359 384 1360 1361 148 1362[305 131 364 184 136 384 214]1369 1373 384 1374[359]1375 1376 384 1377 1378 148 1379[305 131 364 184 136 384 214]1386 1390 384 1391[359]1392 1393 384 1394 1395 130 1396[384 214]1398 1402 384 1403[359]1404 1405 384 1406[771 721 848 771 898 771]1412 1413 898 1414[823]1415 1418 582 1419 1420 587 1421[661]1422 1423 616 1424[695 759]1426 1427 661 1428[501 531]1430 1431 667]>>endobj327 0 obj<</Ordering(Identity)/Registry(Adobe)/Supplement 0>>endobj328 0 obj<</Ascent 1079/CIDSet 329 0 R/CapHeight 667/Descent -304/Flags 4/FontBBox[-351 -304 1111 1079]/FontFamily(Proxima Nova Light)/FontFile3 330 0 R/FontName/DFGCEM+ProximaNova-Light/FontStretch/Normal/FontWeight 300/ItalicAngle 0/StemV 52/Type/FontDescriptor/XHeight 483>>endobj329 0 obj<</Filter/FlateDecode/Length 11>>stream
+Hâö `  ë ë
+endstreamendobj330 0 obj<</Filter/FlateDecode/Length 293/Subtype/CIDFontType0C>>stream
+Hâbd`ab`ddîtqswvı’( Ø»ÃMÙÀ/K‘ı…Lœ(IÍ¸ê˛!”Õ#˜CñÒáÀ9—ﬂü˘ı˙◊i÷~•Ô!¸ﬂ£øáÛ®~Ô‡Qa`edd„sIuL…OJıLIÕ+…,©tŒ/®,ß£ë£©‡õXî≠úôõüWúüß£`d``™ß‡òì£ VT¨PîZúZTñö¢ßÔRYê™`¢êíöÜÈ8 `Lååjö?fÆ¸πh%„ΩUﬂ∑¨f˛·f(˙ÛﬁÔœÔ±øºRÙ˜ñüãæoa„˚>ù‰%ŒÚ<j;æO™õÒ£|˙°È_¶}gôÕˆªlˆÃÈÏrÃLgŒ¸œ√ŸÕ√ΩÇÎ ˜äYΩ}<<' ü“rV
+endstreamendobj331 0 obj<</Filter/FlateDecode/Length 9012>>stream
+HâlWKÆπ‹˜)Í]‚'˘€Zº2√‡¡ûY¥òÒ˝Gd$ŸO“@Ä^eãÃ_Dø¸„ÎıÂÔ_”ıóø~ΩÈ^y^¯ø’+_¸Ú¯Ú∑•Îóˇ= ¥k]œ2⁄’VªÀº˛¯œ„øèﬂÈÍπ“ûm›K¬ƒÎ_øa√<:6lmh√ﬂ˘J¯óØûn´5_≠’ªf+◊«∑ﬂ|{îªœäß◊£ﬁi‰ÎôÓT◊Uo+ÖF^£∑F√˙∏>∞pıNsåyŸùÒúÔäÂz.pcbô,ÏZÎü‘ª˘ﬁ}U3gﬂŒ Ó4π.€¢Q∆∏ =˜„ºç«◊„WÎNk¡ˇ¯BÊá&≥m⁄Ω*∂ò˜JHÂ=ƒº‹˙xt∏RhÊ2ÆÅ0·—∏;¢àu∏åuëeZŒ{LlÿÓÜﬂpÜ˚=∞˘«c›ïŸCP(Ã¬œƒBˆéë}ô˘.∆7UØ˛M¬¶»qô~,ﬁ`éòXãπÚ;Ú“ÒÒ«c†`)´p†c+>O⁄yA¢YÉ1Yóﬁ˝ÂdΩfœó<”Û«„…&[aæ∂˘ÃÕO~1›Á˘Wt‚??u÷¿q”–Y	F∂Oc=KæS3o≠g)(/˘∞rAòìŸ+√mΩÌ¯ÛzˇPUImS’∏ˆ˛≤ÿ zz=;r,K[«˜ahœèáL˝ˇ
+Kéiá‰ˇËVgåW¸˘v~@	ﬁ◊˚l=›ÜÕ nÒ'\ô•}ÓxˇYÿ≥≥ém"ù}Ìç¬–1ôq÷kõÉ≠¢=
+∫‡÷Na–ù?–]˘?ú¯|ß¢˝zw`ë™pF~ m…‚ú ß›yM¸«öyK‚“	[ºÕ·]œÆŒ¨kFoÓØòÄ)|e—n[É∆¨¿| KVH…<¸Sù±`t
+å∆ﬁ J˚Za¢Ω;>GÜ	ks4‘I¨É * áCF%5§t<ú∑±9ä∂skÄÇΩ¯¡´mêPKÏ,.v~≤	È"ª(∏ñú°“päH›»I3/œê†:Ó÷ùòã´Tf4—·¸6’Yö±-˙Ãad_8gˆ¨K˚¯taO¢S&É&ù√0+a`!x€Iâı`É÷·@q√Vüî6LW‘ÏÑ•/∞6ÏÖ˘‘H5wûˆì©è)ºô"1Í˜Ãî…H∆!jÌÆÜ˙nD90â∆-÷Ú∂lyª.1í7a‰ (ÃTNéme£Ã¶ÀxÄgÀáB/4]9ZÔÊÜ/çÊ‡P+F√µ{ß^**_Ó¥≤W∂6oSÍŸV´÷µë∆w=)Á∑Q˙‘¬nçò]eÔàìÆ¿$ê=
+pH√Te>√·¢qçÿ,CÕ@,…åj‚£ınúΩ¬
+“5héÍ-AÏ≈{ömjˆâ«óÿÉïfiºQY, ±c§{Ìπù‹W´
+çıY4&yÄà˙=VQ}Ã«$Õ(	å<w®ö“T@m8Äì^KÄ-£Ìê¨¥ë∏H—‰ûÅ ¯ú®r†)<»6Wê–a2$?â≥ïcüMæP¶3›Ù“ ºÂTTù,˚ﬁëö'@*⁄	 äêJkr1;P⁄;ÅîQ˚øD—;õ<Ug«‘]Ïe…≤≤ZêµW}$Án¬á=@ÔƒﬁO±2ea5ïÜ¨˙§3Ç∞xåX{Y≈45IÂ1YbK5ﬁ|x>•i:¯Ü`OkR°M
+û∑Ï"gËh9å*‡r˜·˙2•Ë$ﬂA}‚ÛW`Í∂<x3QDÜ˝ÄƒóËS≤¯¿vdÂÄO4,#¿@¸íâ\∏EV∆-¶ÑÊb‚Ç˜≈ÅÂh›]¿ vSîÌäπ°(SŸÔ"≥ÑøF3s™Fœ#ÅJÖTÃìPÕ«DÒtèÊ™(≥cMïÎÕŒú·<¢ôoË>ëd©qìi<Ù?gÓâõ'“á⁄˜b¶‡S›Ú¶.lÍß»⁄c]j#´Œ◊é9l®õeˆ∆v[€∫û√~∂!|ZÊ=√[¢˝…†n€TU?h™˜H∆œÄı—1Ãz˚_VÙw˜A4∂°4›—ƒí!•h¬»î€¢KfıG≠û;Í(X3≥¶˘]^ì⁄3…A+dÎ8”òÃ# àO¬,[Äé¶π—Ó5hí≥UÕXT'kkCœE\†™*9&Ò1™◊´⁄:¨T‚^C,]™äøÌsJhû¨7aê—Î°2˚–ÃA“™Ω€î¿öGUê2õ˚˛dÆ}•L'Õ£ò˛êÖ“hÙ™∞ö^µ5Ôß‚7^NPjYJÿM-Ã@¶ì.I$ñ3˙FRÍ[òdj%YòGuKiS¬EÚGUıXZ%62å9Ω9ìøô.˚Ÿ…âWﬁ©<q*ÖP’¥ÉˆÏKSÜ"Yœq{§ªçP6EBWèµÀ/√ªæÁÌXÃÂQ9ñd`œ3g⁄h?◊ZŒ™Ïó9Y$zwBäîÂΩô
+§NÙC˚º(ÙqûÓ0Â“∞≠Ô¸vq@^ˆG2èU0)ß÷¿πz$‰ÿõ	òm*i›o2>#ßìÑ@Ó∑™LÎk´ÇzUOÙ%≥cÑåÚïa;)ËªÁπøPAx-$Ñx<-ià|d<,ke'√]M≥ùi/U©Ïú”k\%zÓ∫…æïÑûœÃc9„≤˚-“bı⁄ ü8∫6Y{|≈ΩcÊWJ\®^Fjc“cåÖÈIãÛEÃ7çaé1WOÁÇ≥˙÷èBq\∏í7Útx˙§ﬂÜìå∆¸«#Ù∏æ{msﬂ¯ÇePìÆæC¯Osq"#‡¡Ω©°n˘ƒﬂE◊¬íè>€ºÌ±™-v.É‚Á`Ò◊∑l˙9◊6Q:≤j∑î“ñ‘5MºE]{Ùº¯6é<'Æ"9‡≤*
+ Qéx4Átÿò$ÕD˝â„e≤Ω_4W:5Aˇf¶yñ±çÉVô!ŒıÂ”⁄Ç”u '∑I=Îéê√_
+G CëÓé(ßπv
+∏eÖ‡@~ƒ§ë:∞ÄÌ¥˙Û—kz√˚dæ§˜RÖ}2Ò&Iπ$»_v•æ°"}=‘~h÷K
+D7È≥Ö6âqœ"-§VÏ	]Ë« "ZPFM=2É˜ 3∑h]p%í79Ï_5bWéÉQçjÙhı Ü√CÛTWXÍ]óŒ≈o≥aÄ∆^w⁄Y{*'è6Ê>Ÿ±—ﬁç∑uÀ·.°@≥L◊µ\º
+‹aEõp!re ÷œ¡tS#{Eã7q)hEX	Dl‚5WÍ‹èék∏o™s¿ã<»?◊∆ù1ÑöA¸,Œ˙M"GG˙&	¸±gáÆ{"*—Ü¸í‘eFm¢y_4õ‘S?3U£õ™o9∞&qàˇÅIÙ"6r°¯‰Ær¢UçèŸ’«Í„⁄ƒèôY∂∑(ÚÇ*gK·	‰ÂòŸﬂ∞kCŒu∑í∂ÁÏr9ºc§≥`[(F7§ÀÑÓÏSé”MÚd"â%7∏ÊwBRû!&çwíò˛™ˇÕ¨?∑Ú[Æüˆ√ÁÀç€—;“€O5}¸ÔGæ_Ät#›ó>HÎ{D(.∆íí…»U>yèW;øgÅ9äZ‘54inm≠#≈!2Xb¶%L–Ä?Ø∑_U±ÉΩN!í"9Ÿ≈w€ÏâN({›¸ÎÖéõ™+√	a°lﬂf≈;∏w2Rõûã‚Áä¸ûR|ØáDŸs∑°À ±äòıˇ¥W]oc«}◊ØòGª®¥Û˝∫€6h—>§+†õ – wm5≤dH⁄l∑øæá‰‹{G∂˚¢	ÇX¢v»!9‰·aÖ5Ú∑$>HôXû¨(ñóÚ¨q|PA¿B%S·ê£dC™éU(0Y‡™ï="J5ï^†öL≤„êËòRíë@ÕïÃòŸî»è@ Sxï¿ƒ“1§Eûú√Ä¶ö≠€åc:8&«≥CKUÀŒ*Ö"ÛU∆Õ@-†®Ù‚v-oUÏaKD±ÄÔñ∫ï+∆ó°Ω1|x7¢v!x∑™ﬂU∆û~ÇsZ”¬áD˚BC£úë%Sã_Î’{ÿÛ¿jjœπ⁄—oîB
+π—rI5≤ì‚–∏ıu ^˝l„Ry€À“ï€YeçËQµg –Z…ˆuô´¬‡:Ù≠>Ù},©.ã≤RÊLHu`àªÚ]∆øπ AÊÅ‡S]=dÆ¢	“∆X“J‚®‹i∫ÃÖΩ	Yb-∂	⁄"∏ö4≠©©Ågzä°ä€^ú£Hå≥c¬û˛ \ésbi‰˙:ïÎçóìJD˚EF°ÏTÏ)ç£⁄-2®yhI´`xÔ≠Òq`5tnF ≠‹î_Â{üië∆Â4/älF∂X∫çv!é≤§µÔ§ËfƒÅ|æ20¬À˛8Ø?ÏLV˙t7EöúGâLÛZºú√¢Í°∂∂Ùv∑≥ä–OdÉ2Ñ∫uKz˙√P˛‡«ôAJc˛Öò◊uI@IäÀÁ∆˚∫@¶‘ò≈î$ïöò?q€µ™ïLp°è”
+0%Jˆ<âäHî˚Hî-YîiXTjXT>cQ·yœXî˚eEÄù<ø‰–Û¢€—ÛED7#¢xN-4Õ5-¥Õ?œ—B√—®Ù**J|}üÂå{ŸëzQuÎ°Ãõ^`y§^vd^d≠e^‘•Û
+°e^˙úz—Ø˜Ú~‰^ºaå‹ã¢∏E?r/‰•Â^…6‹´¥‰+ªñ|ÁÚÂÛHæËZÚ„»æºé˝JÆ•_ ¨ë~Q£ıÙã∑»ë~—\nËW“•°_“Ûï~	ñ˝™q§_y§_¥·∂ÙKR•_—7Ù´4¸K¥G˛_G˛U¬ˇ f‰_÷5Ù+∏ñ~•0–ØÏBCøb>£_‰”@øíiËóå§Å~çHWã•Á_Fó3˛Âeù	òt,]<J4wŒªYf«w≥∑K™∆$ Ü•∑≥7KÛ#ÊóVÀO33‹Ä÷éjy3˚p[ÍÔ◊œ≠Æˆ∑{ın€≠«á’∫ª˛a˘7Ú<3±˛V{ÄQKˆtÖı»;õ¸ÎIméjsˇ∞?úVªì:Ì’O◊π@Ø\u›ÉZÔ¯∑’©Srb»j˘'®ﬁØ?]GuuTkÚCÌ?©’Ó´⁄üÓ∫É∫=¨Ó6kQZ˛«ªmwﬂÌN«ÖZ^ƒ@ tµWáÓˆÛñÃüÓ6«ﬂ√ÇÍÆùï˚ˇs‡øZo?œ{3W«Õ~ß˛ªﬂuÍnuTªÁèß’«ÌÊx◊›®ÎÂø˘ÿÍ∞ˇºªÅÕÆ	Ä∆Ì∏áœ5°–ïÕu„%õ›Õf›£ò⁄Óè∏ÌQ&ÆûF]cU˚É∫ÔéÛﬁ´„ÍF‚«N=ÏèõÓÅ”õ≤Ä–≠»ön$ó)±Ù˝¯ı˛„~´6ßc∑•Tè—Ó?Ê˝9≤[›wÍ{ã˜ÖŒWdÈÁN≠˙ìÆæ«ÿï8qqÎÒnÛÄ„´ì:ﬁÌ?oo‘Æ˚—IáªÎª’ÓV|•[æ¨æ.$âOÍ˜ùF˝Æ_Jë˜¸“»”7lZÎ¥Nˇ[»o!gNk_ ˇ2ƒàﬂì©gÒô¢ú1¿√∑ÔöO˝á˙ê∂ﬁ‡ˇ(ñ…)±ñßìı3í∆üó†ZE\…*á≤†Ê¨‚°õ˝KÌ(2‚&˝_@?øù—Â’Â’?‘!r¸˜≠n‘ÏÕ∑Ôç∫=6Ù≈õH¯Ö°hÏ"I}±ìËßÔœ8œ®‰ë3M…AâÊ$%¥º5†ªìî(_Ô—≥ŒORc¥¶âJJ”níRF÷/+ëö◊âáíçòQ†øÍÉÅÏKôV@Ü»\, ë@|Ë≤R|À|+1='Ç+Xà):É6x?E'h‰,ô¢câü†„¿$zgäéáè)::zbêkå{7I'µ”ÚñÖGMQ)PâzR™#û‘Y?)’`?ÄÕ<…7p217)’—ŸLìRQ&õIÌÉ}	¨/LÍ\ìÜ¡ÑSúüTÆÂh'=©Gµ•¢ß≈É“I¶LJ[@DˇöÄ- ?‰µ(L€âh±7ïVX›åÖˇH"h6î¥ùæk˛{WØ∏}
+µÕ{G⁄üÚ§«ãH*x∆¥ﬁBk7ñ#§e“„%ç(ÜWÙ…wØ`A]î„·<œØPß◊„R÷9	˜à•Â∞j`Óô°€+Òx⁄=R2£ﬁÍóÛ+#ÅÉà"¢lÉ¥tßÈï€@Püµ·∞™Êñg-<ñ.∞ÀÖ	doNøá˛˜;^„û±Á∞¿ÙœhØ*ŒãÛﬁ§‹4?3I.£Z·r∂‰≤∑y°°Ó∞Fö@˜[¿∫¸≈;}íUÂ=ÆêÙ<≤k4¢`T‚*XW…ïÂ˝œ+π0m°‡G1xe
+ò£ÿj\xúk‚Cô]êoﬁô1}fg9dœnrcîñ?Üﬂl–ﬁZéº°#O≠˘:xR!$p|‘û[5ÛpÈÃözu‡g/q^˛/Ê‰˝¯"óœ"‹&øòØÏÈÅ+ØLW
+1øêÆ¡⁄oúÆöÇ&]ÑîŒæ\nè#å˝·˘.ñW,ÁÛ+ +º≤\./Çgü¢˘ Î≈<ì/Ç_ãO:küuÈ≈|«ã¶∑._ ópxCFÛK˘
+tJóÚEû∂÷~’|]Ã¡3ÌÿûÌsÎ^”éíØLæÜ~îszE?ræú~&_C?ûY˚U˚Òbﬁ”õ‡…"`ız<:Q9⁄Zö'P0©u0óÑà≤–hsúƒB·ŸÎH¸=D(Œ¸ù
+© ≥D´íöcH°,´`— 	Á™≥∞íG≤ëI¨môÑÿúEØB*8ÄpÊ¥9 ªâΩ∞ñ)L_iÓB¿h4ha
+Åï™ºÖ≈‚¬ GDN≤
+2ó(,9ds=Kò¸ƒP≈$ï)eúBzÒ<AUf<»·¬TFrÒJ÷3	@‚ÿÕ2å≥xz)†Ñ∫¢˘M◊WT®íE*≠úeDqıöM«öiB÷≠"Gà„ë0Pcp‘·’®((Á W∞‡A\BMô©Ÿ1‚-Ò¢d˘e2NÅˇ#8qìv0˘ÒP˘æû!>üE‹ˆ‚‹‡mÑﬂs+<"kxJ|œP4‹äñ¢ƒ%7∑	‘Ø‡˚ú	º1”ìã`SéTo
+kâ\PFı6j’íÆòØ"ïM˝äµM/¬zvΩë*»ÎY˘˛mïƒ51°˘?x¯Hƒ ÂAÔá¬.C~@n©(I)∫Z¸s∏¥mZ!Ê^⁄‚ïäÔOFZz#Uê+÷3´€^DS~<OÛbëë!1_r^nØ?êØ‚\˝aNL=äuÕ/ÓãÂŒqxÄŒ@Ö1^¿∆Âf5
+IˆM¿-âfÁò3`ËK\¸öíÌÒMkŒ<FCc¬.
+ö („ VÙÊÙ#≠%\BCwÄ5s˘@pπ|0£Ãq-ÎzÂùÆP£g‡≈FëäÒ\$Å‡!≈ÿ{H@‚©Ki.ìã"”„¶1ˆúóKè$IÑÔ˝+Íÿ{»Ÿx?Æ+$Œàæ‚0ÇRH,ˇ_∏ôyDFM˜äóôÚÍ¨»w≥œmıˆ!Ü85;Áª~ gﬂ$å!8-ñ]€¿®çdÇE’d¿Re˝ÜXA' 8≤a;ˆKìã¡ õ"[Ü€ ™Ωg?l8±}i5ﬁ9ˆ†j¥æÎ Ög@Âf≈sÕcÅΩYüÌ1sâÅ¬ΩX⁄¡s∂$C∑¥ﬂk7xπ9øª+Ú«Ëy>ôîôë4Ó'±÷ªˇl;¿ç†®<-Í÷Ô$jò¢⁄úä)≠èRû
+≤Z√#É,¥Kn∞	]Ä≠Y£dŒï¥¨,ÂBüc2´‰Àö"†`z†µ5>7Lõ-≥—d◊w≥´¥(Ü∫ —KÆΩX=¥¨ã´06Ç…<§r¿÷P∂M1£ 6–Fa*ˆ≠mÁ»w0G◊s1:¡ÙıÏfﬂÏ“!®C˚À÷é6»ö∞€A*g€2ev¥⁄¢ƒ®•Ú6ª9ÆNm¸ÜmTeÎ˜Æf70,¥NÖ@∞˙ƒÅïa≠Äk∆Ω®F!VG„‘r< oß¥Ú–Ÿ.ıµ5@ñ¿F¸≈pN˜ìçu˙ïÿØÊXó F(û˜éÂÕ6/=ÅÆâ∫õ≤•Ï8~Îîãf´€≤CúhjK*x‚J,*ópŒ,C=©òbGâô∏˛™gcCZ‘ª'Î@ÜwÁ¥∫¬¿jÕ∫Û~ãÆ£‰Dtkjﬁ˝H4®êU≥Üéï∏$õ
+ yıˆπ\s•·ó™–ZgzgCZ/Ó∆o
+ù®!v]¶Noµïc˙/)ds^j>™ÂrØ"T=ßla—>∞≈0∂í≤k-òâV1î|_@EN<9ã@Ïç¿:™ª/.oˇY'nZö
+îÿ€∆Î≈¢ÿtøŸU…‚TQÙ©tÀƒ›˙(§u±T÷"^•ªÔè“nyó◊≠_ò"ûä∏˛™‰™™›§m5Å¶Ú©fçDT[ºÔ>aYÎù≠Îaúu{&-¬D≤èDıí–™´/πÍg‚m‘¸•umû∞¶DÍ=Ø?Ëe3â©ã∂ïYDA·◊i%Vx9∞úö¿Í√GÜ™ªkSX˜j€¯•~[ıÒ·y(„TYG3Q¢äj™oëufGüöÚQÕ¥&zq;Ú‡H$jÈXÖ3›–^ïò÷Ô¡ΩY±çdîç‡√lœ∂JŸ©t∑›Ø´ÍG±Äﬂ¡—∫i6öÊjzﬁAÃtZéœ>!™˘À…ëí∑B‘≤jºπ¬*C2SÅxïí≥î§’[7(Ï‘ˆ*ﬁ3.Òﬂeäˆ™é[t’$¯ÇRFªK•eH©ÈtWáÄ∆;Nòb∏Sÿ°óf·@Í«áèÇx˝Ù ù·°´•~ÙU\ß◊ç˙Óõá“ôwèÃòÚC*ã”dﬂ¢dÑóáõ•=eıFC4
+wÑ	¡#^ÿ •CÇ(Æ ˘å@2@¢ñ˘òº[Ï∫ádíf€@eUÄV˛4‹pçìÒ–·µ\ÏÄ™0VHØL£ÌgpT>S0@ÛﬂEyÈ!’∫‰ëﬁêz•©A©∑o—•dRS≈e%<WÂîR˜£…˚˙Q≥¨qıUne8}yël.√i2ã^ûc˜)‘èQà÷∆É–˚L ∏ÅZT;òµÊ±#◊)=Ï_P¸∑◊=–ƒ6W∏â1ßÙ(k⁄àÀH-
+íH‰Ñw‹J€Œ/ TítfXlˆöµh∏ùªw]aÂ£˛.›√-«Iôgñ!)E÷≥&ƒVñf_bgç≠ôÇmoY±2dí¢&˙πéßãÀúah©Ú˝v®o‚I∂≥˛j≠¶nÓÀÅgÙXµ‰◊që~ıÓ—¸\zcK≥û∫¸É9fÎµlyŒ¡Ñ¶∑gsdJˆhÅÀ+EûÆ≤`.IE~˛-ÂÆ‰u)–ûÉ.~¶™û‹’Ò69˙´Èªj/	p8uËç∆ô\î≠e;¢í©ù˝∏GY™˘—ız+ΩB˜;BËè_âëDÖ>†ò=ÿ-ªBà≥ˇ QJ+Ó—G/ÔÏœ=0Ñ=K…0x6;ç ‹œ99yx¶ïgWæê!I©'JWflvÛøiæ˛«Â]P–!y\Aé]+µ'u wåÍÖzâRQá(@€“ÏŸ¢ãÜñ2d2G›î≈=”^1ìD˚∂o€µÇGTu.6Cgf†Ñ	 ã†$üvã≠Üó0ı…Tsi÷∞mbc=πT·ºn#.dr8ä^¬]$Y©-áqO6±"'vó∑Ø‰=„Iı!G;^ŸÖ∏`FJÊ‚Æx¥çm˝’[— .NÛæÇÊ‡-LÉ£ù√
+˝ uΩªÀÖF‰{ê–IÁ ÒbDl^∂ø¥OßC˙øüÄw>néeWó œ[[6b‡°“/˜åÉ…áWäâv&D\#è*';%!	f∏ûq€-\à	DÌ&é6
+\â„õCô~±V¿î °jfôFÆºˆãÈ*?)®8*[–‚2ıo∂v†)aÇπZµKÈ¯ÃÚ1o …#¥UEJâå7lw$ñQÍlç©±e.Ùÿˆ&Û°≈È@Ö∞M[§»U]¬˙p?{â«oÁóÖî∆7sB‚∏ÚÉqbﬁÏœc·Ç9(⁄ƒ[hû£ﬁä<± ì–}Á“¿MCh'ã‹4Ú‚!≈·"T:≈€ÖO⁄^¬Ü¨&Äík‚y¶∞Nlbå¬í†ñvRê_6á7ÍJkT†∆ô.ƒ0◊‘Îíd«n÷m·ΩAˇ±,‰`í‡‰b7üÌ¿IÙ7®çî◊5ÔÎ6L© HÉ9≠ƒL„òtá‹tæ<iÉòk0Aåñ âäÔÎKîÈ	€kë˘‰ºäJ*ì•–ô≠ëˆ§B;>uö«ôΩ˙á°Êe—Jq8‚9Ò|ÑxéTjIéŸß[//”/·ÄO”ò÷«äﬂèq«K…<ÍZP&™ÂnÕ˚›ˆMıDR¸ÁcO6wãølwl'ñct ÁV±ìûä6î'MbVMõY|‰69'OA˜◊◊pÀÃ£˚PãIÑMö‘ﬂ•{/ìhõ‡dmΩﬁ‰~!eﬂWhΩì`·Hı(whGÕC,û&KÖ©ûê7_≥˚‘IÅ–9Õ@_¡<Wºäq~QœëÓÅ‰∫ëP‹i˙+
+ÖV‘!≤5E7∏
+B 7i—*&÷« (æ∏ÉSJsa™ºyµÉd6XHÕ≥£œ2|+MÖÔ+ƒ≥ó;]ø0˛äM	π±_åb:0Îª´¶√Y}Ó‘\KõmìAÅ˙ÿ¢JßÑÓ>≠9¨˛3‰1∞l—ê¥g8¸#x)è¥ÛÃ@π‡ìô‚¶5¥ZÏÄe6{»~Wh•iÓ[¯Pˇ¶h7ë£©«≥£˛©Ùª∑À° Âc˚¶≥π¸„]`∑íè)èhÒ≤b.˚˛r…føŸçºÕQøêS1FnqkÉØofíF‹‚¢§ R?ıÃ¯¯ò;çWÄf( OaÇ∫6Y*¬CN.é¯>´ªÜˇçTÂ@™ÙÑTÒF™8Sç_a™~0U:ò*˛?LUN¶ 'SÂ≈TêÏæ$˝€éü$Ωüí>~£§èS“€ñtP[>®≠‘÷û®-~NmqSõ6UY.„f£5kÙI'éÅ≠6é·◊á'C¸+8F":q,‰«8l+ÚˇÖc}.”6ça¸8hLƒ	“È7ç!1ççîC◊;éeMh«zπytÛÿ»'è°lCümÎx˜…cBù≈chˇÕc©∫y¨öÕ<V¬¡c1èÉ«⁄|‚±⁄NÎ7èç<O+π-Îõõ«F=Å,äè»∆∏Å,ïì«ZÃ7èaÜªy¨Œ'ÎÌÊ±§]9èâI7èÕyÛåg„XOO8í^8÷ÁçcOÎ)}«clﬁ=⁄Q≥+|nlY…^~zºÊ˛˜ﬂ?ø¸¯˚?∆«œøº¸¯ˇ
+Q|˚˚f0§<Ê;	–P™UI1Òy˚ˆÚß◊ﬂ˝pY_ø˛Õ˛+è◊?õ=€ßÙx˝Á◊|º˛√Ç¯x˝è˝◊Ÿwˇ≤ „Åøº˝ó“2Êi¢âˇ∆°–vÍ¬T*!$ò"±tqÎ£>ö⁄Ulß*øûãù™làŸgøÛ˜ø{%gW…˘$π(íã_í2Û…‰ï?,9®«≈'§@àñ–˘ΩW‚-ÍpD∞>u[BH}Ôì3dpÊh±ÎH˜'Ωìç‰§Äê[ôÂúG˚,"ºÂé„⁄Q6≈Ô˚^ü,Ô@…I©ˇîí,uì6ªA⁄‹I{Ì)!–\/˝'g˘¶f¿c˙ÂkØ
+¬	ﬁ±p=Í©¨≈bÖŒîo»óˇG.A:_ _:\Vo’\f§⁄„Ï˚|äôzÜ9±‘%≠÷≈Kº∑qƒr5'#4<∞°— v∞∫˚TÚ’M¡ﬂﬁWı¶^›é|¬K9ÊãçjT˚U≠€j˝∂Bı#¿ Áró≠
+endstreamendobjxref
+0 1
+0000000000 65535 f
+2 1
+0001277877 00000 n
+10 2
+0001322936 00000 n
+0001323397 00000 n
+95 1
+0001323950 00000 n
+290 42
+0001324169 00000 n
+0001324311 00000 n
+0001324455 00000 n
+0001324598 00000 n
+0001324743 00000 n
+0001324884 00000 n
+0001330073 00000 n
+0001330100 00000 n
+0001330407 00000 n
+0001335532 00000 n
+0001335602 00000 n
+0001335882 00000 n
+0001335967 00000 n
+0001336464 00000 n
+0001336491 00000 n
+0001336789 00000 n
+0001341900 00000 n
+0001341970 00000 n
+0001342263 00000 n
+0001342344 00000 n
+0001342743 00000 n
+0001342770 00000 n
+0001343068 00000 n
+0001348166 00000 n
+0001348236 00000 n
+0001348524 00000 n
+0001348605 00000 n
+0001348995 00000 n
+0001349022 00000 n
+0001349320 00000 n
+0001354402 00000 n
+0001354472 00000 n
+0001354754 00000 n
+0001354835 00000 n
+0001355226 00000 n
+0001355253 00000 n
+0001355551 00000 n
+0001360680 00000 n
+0001360750 00000 n
+0001361036 00000 n
+0001361117 00000 n
+0001361503 00000 n
+trailer
+<</Size 332/Root 1 0 R/Info 95 0 R/ID[<15C714B85E4E4D4F8AB0F10B2A2B6432><8BE2586679BD2B4BBDB066F7646F0E8B>]/Prev 1277182>>
+startxref
+1370587
+%%EOF

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Presearch Logos & Brand Guidelines
+
+Presearch is an open, decentralized search engine that rewards community members
+with Presearch Tokens for their usage, contribution to, and promotion of the platform.
+
+We created these guidelines to help authorized users of the Presearch community
+represent our brand and identity in a way that is consistent with the quality impact and ambition of our project.
+
+Using these marks accurately is a serious responsibility and is regulated by our brand guidelines. If you have any questions please contact brand@presearch.com.


### PR DESCRIPTION
The following changes from version 1.0.0 to 1.1.0: 1)  removed presearch.org
2)  added presearch.com
3)  Removed reference to presearch.io/brand
4)  Updated version # and date.
5)  Changed brand@presearch.io to brand@presearch.com 
6)  Updated readme file

Addresses Open Issue #1 
https://github.com/PresearchOfficial/presearch-brand/issues/1